### PR TITLE
Launch Ochat documentation at ochatlabs.com

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -54,7 +54,7 @@ jobs:
         environment: [preview, production]
     env:
       SITE_ENV: ${{ matrix.environment }}
-      SITE_URL: ${{ matrix.environment == 'production' && 'https://release.ochat.test' || 'http://localhost:4321' }}
+      SITE_URL: ${{ matrix.environment == 'production' && 'https://ochatlabs.com' || 'http://localhost:4321' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     defaults:
@@ -78,6 +78,26 @@ jobs:
       - run: npm run measure:performance
       - run: npm run evaluate:search
       - run: npm run test:browser -- --workers=2
+      - name: Retain tested production artifact
+        if: matrix.environment == 'production'
+        run: |
+          mkdir -p .release
+          npm run artifact -- retain .release/candidate
+          cp test-results/.last-run.json .release/candidate/browser-result.json
+      - name: Validate Cloudflare production packaging
+        if: matrix.environment == 'production'
+        run: |
+          node node_modules/wrangler/bin/wrangler.js deploy --dry-run --config .release/candidate/wrangler.jsonc --env production
+          node node_modules/wrangler/bin/wrangler.js deploy --dry-run --config .release/candidate/redirect/wrangler.jsonc
+      - name: Upload tested production artifact
+        if: matrix.environment == 'production'
+        uses: actions/upload-artifact@v4
+        with:
+          name: website-production-release
+          path: website/.release/candidate/
+          include-hidden-files: true
+          retention-days: 90
+          if-no-files-found: error
       - uses: actions/upload-artifact@v4
         if: always()
         with:
@@ -110,6 +130,58 @@ jobs:
         run: |
           test "$SEMANTICS_RESULT" = success
           test "$WEBSITE_RESULT" = success
-# Validation only: no publication credentials. P11 may add one publisher that
-# requires release-gate. Keep Cloudflare Git auto-deployment disabled.
-# The reserved production fixture origin must never be deployed publicly.
+  deploy-production:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.release-gate.result == 'success'
+    needs: [release-gate]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment:
+      name: production
+      url: https://ochatlabs.com
+    concurrency:
+      group: ochat-website-production
+      cancel-in-progress: false
+    defaults:
+      run:
+        working-directory: website
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.sha }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: website/.nvmrc
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+      - run: npm ci
+      - uses: actions/download-artifact@v4
+        with:
+          name: website-production-release
+          path: website/.release/candidate
+      - uses: actions/download-artifact@v4
+        with:
+          name: website-semantic-evidence
+          path: website/.release/semantics
+      - name: Verify exact qualified release
+        run: node scripts/verify-production.mjs .release/candidate .release/semantics/semantic-report.json
+      - name: Publish qualified release
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node scripts/publish-production.mjs .release/candidate .release/semantics/semantic-report.json .release/deployment.json
+      - name: Verify live production
+        run: node scripts/rehearse-hosted.mjs .release/candidate .release/hosted-production.json
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: production-deployment-evidence
+          path: |
+            website/.release/deployment.json
+            website/.release/hosted-production.json
+            website/.release/candidate/approval.json
+          include-hidden-files: true
+          retention-days: 90
+# GitHub Actions is the sole production publisher. Pull requests never deploy.
+# Keep Cloudflare Git auto-deployment and alternate publication triggers disabled.

--- a/Readme.md
+++ b/Readme.md
@@ -2,6 +2,8 @@
 
 **Your instructions. Your tools. Your workflow.**
 
+[Website and documentation](https://ochatlabs.com/) · [Run your first agent](https://ochatlabs.com/docs/start/first-agent/) · [Explore applications](https://ochatlabs.com/applications/)
+
 Ochat lets you define an AI agent in a text file and run it against your project.
 Use it to understand unfamiliar code, review changes, update documentation, or
 build a development assistant that works the way you do.

--- a/website/README.md
+++ b/website/README.md
@@ -1,5 +1,7 @@
 # Ochat website
 
+Production domain: **https://ochatlabs.com**. The protected Website workflow builds for this origin, retains the tested artifact, and publishes only after the main release gate passes. See [the production launch record](planning/p11-launch.md) and [release runbook](planning/release-runbook.md).
+
 A static Astro/Starlight website with an application-led homepage and repository-owned documentation. Six application guides, an inspectable recorded workflow, and a ten-lesson curriculum help readers discover and build useful agents. The catalog contains fourteen entries: eight complete examples, five configurable templates, and one illustrative reading sample. The preview renders 123 documentation routes and accounts for 308 canonical documents (110 published, 4 compatibility, 9 bridges, 175 repository-only, 10 deferred). Search covers 114 approved pages with 21 benchmark queries. See [the application UI review](planning/application-ui-review.md) for current scope and verification. P09 is complete through user-confirmed API-reference deferral; P10 and Milestone C are complete within the approved launch scope: local qualification, hosted preview rehearsal/rollback, and actual GitHub release enforcement pass; manual accessibility review remains explicitly deferred. P11 production launch is next. See [the P10 review](planning/p10-completion-review.md).
 
 ## Run locally

--- a/website/config/production.mjs
+++ b/website/config/production.mjs
@@ -1,0 +1,4 @@
+// Public deployment identity; no credentials belong in this file.
+export const productionOrigin = 'https://ochatlabs.com';
+export const productionAccount = 'ec3ca23aab8456f6369df62e5c6a982c';
+export const productionWorkers = ['ochat-website', 'ochat-website-redirect'];

--- a/website/config/release-prerequisites.json
+++ b/website/config/release-prerequisites.json
@@ -1,0 +1,20 @@
+{
+  "hostedRehearsal": {
+    "status": "pass",
+    "reviewer": "Codex review of recorded P10 evidence during P11 implementation",
+    "reviewedAt": "2026-09-08T02:44:03.221374+00:00",
+    "evidence": "https://github.com/dakotamurphyucf/ochat/blob/a93fcd1df8e6524659f4cc1e1c6c34b1c34b93c8/website/planning/p10-hosted-rehearsal.md"
+  },
+  "hostedRollback": {
+    "status": "pass",
+    "reviewer": "Codex review of recorded P10 evidence during P11 implementation",
+    "reviewedAt": "2026-09-08T02:44:03.221536+00:00",
+    "evidence": "https://github.com/dakotamurphyucf/ochat/blob/a93fcd1df8e6524659f4cc1e1c6c34b1c34b93c8/website/planning/p10-hosted-rehearsal.md"
+  },
+  "remoteEnforcement": {
+    "status": "pass",
+    "reviewer": "Codex review of recorded P10 evidence during P11 implementation",
+    "reviewedAt": "2026-09-08T02:44:03.221538+00:00",
+    "evidence": "https://github.com/dakotamurphyucf/ochat/actions/runs/34177137660"
+  }
+}

--- a/website/planning/decisions.md
+++ b/website/planning/decisions.md
@@ -18,7 +18,7 @@ Custom Astro homepage owns `/`. Starlight owns manifest-declared `/docs/` pages.
 
 Pagefind runs once through Starlight. Explicit `pagefind` frontmatter controls indexing, explicit sidebar entries control navigation, and the configured sitemap integration filters by the separate manifest field. Preview builds are noindex in HTML and host headers; `robots.txt` disallows crawling. A bridge preserves headings and is omitted from navigation, search, and sitemap. Aliases requiring different fragment translations are not silently accepted.
 
-The default origin is `http://localhost:4321`. `SITE_ENV=production` requires an explicit HTTPS `SITE_URL`. No candidate domain is treated as owned. Local preview listens on loopback only. Development/preview use Astro's public programmatic API because Astro 7 automatically backgrounds CLI servers in an agent environment, which breaks a foreground process supervisor such as Playwright.
+The default origin is `http://localhost:4321`. `SITE_ENV=production` requires an explicit HTTPS `SITE_URL`. The user purchased `ochatlabs.com` through GoDaddy; its zone is active in Cloudflare. Production CI explicitly uses `https://ochatlabs.com`. Local preview listens on loopback only. Development/preview use Astro's public programmatic API because Astro 7 automatically backgrounds CLI servers in an agent environment, which breaks a foreground process supervisor such as Playwright.
 
 The root Dune file excludes `website/` from recursive OCaml builds. Narrow `.gitignore` exceptions expose authored website sources while excluding dependencies and generated files.
 

--- a/website/planning/p11-launch.md
+++ b/website/planning/p11-launch.md
@@ -1,0 +1,73 @@
+# P11 production launch
+
+Implementation target: **https://ochatlabs.com**, with www redirecting to the
+HTTPS apex. Production deployment is pending qualification and the first main
+publish. This record does not claim that an unperformed live check passed.
+The deployment history and immutable per-run evidence are available from the
+[Website workflow](https://github.com/dakotamurphyucf/ochat/actions/workflows/website.yml)
+and [production environment](https://github.com/dakotamurphyucf/ochat/deployments?environment=production).
+
+## Domain and ownership
+
+The user purchased ochatlabs.com through GoDaddy for **$31 for two years**, with
+an **auto-renewal quote of $45**. The quote's renewal term was not specified; do
+not reinterpret it as an annual price. Registration and renewal remain in the
+user's GoDaddy account. Registrant contact-email verification remains owner
+managed and has not been independently checked here.
+
+Cloudflare's API confirms the zone is active in account
+`ec3ca23aab8456f6369df62e5c6a982c`, zone `3b704db6095d687c7170377de4adf7f1`.
+The .com parent and two public resolvers agree on
+`justin.ns.cloudflare.com` and `savanna.ns.cloudflare.com`.
+The account API token was created by the user and stored directly in GitHub as
+`CLOUDFLARE_API_TOKEN`; its value was never requested in chat or read locally.
+Local Wrangler OAuth is separate from the CI credential.
+
+## Publication behavior
+
+The product, commands, and repository remain named Ochat. The owned domain is
+passed explicitly to the production CI build, which generates the canonical,
+Open Graph, sitemap, robots and search URLs. The preview environment remains
+noindex. Deferred odoc API hosting and manual accessibility remain deferred.
+
+The protected main workflow qualifies the artifact and retains its static files,
+redirect Worker, reports and SHA256 inventory. Only the subsequent deployment
+job receives the Cloudflare secret. It rejects a superseded main revision and
+publishes the retained artifact without rebuilding. GitHub's production
+environment only allows the main branch; publisher concurrency is serialized.
+
+`ochat-website` hosts the static apex site with real branded 404 responses.
+`ochat-website-redirect` handles www with a 308 redirect preserving the encoded
+path/query. No models, databases, API endpoints, or visitor authentication are
+introduced. The redirect Worker has sampled logs and traces; the main site's
+static requests do not invoke Worker code. The zone's Always Use HTTPS setting
+handles HTTP requests to the apex. The two Worker updates are sequential, not
+an atomic multi-Worker deployment; failure of either or hosted validation marks
+the deployment workflow failed and retains diagnostic evidence.
+
+## Verification and recovery
+
+CI keeps the OCaml docs check, both website matrices, browser accessibility,
+search and performance gates. New checks reject production evidence with a
+wrong origin/revision/hash, failed tests or changed redirect code, and check
+hostname redirect path/query behavior. Both Worker configurations undergo
+Wrangler dry-run packaging before the required gate can pass.
+
+The deployment step records previous and new Cloudflare deployment versions;
+GitHub retains each production artifact/evidence set for 90 days. A first release
+has no previous production version. The P10 baseline/candidate rollback is a
+qualified preview rehearsal, not an invented previous production release.
+Prefer a revert PR through the same pipeline for recovery; preserve downloaded
+known-good archives beyond GitHub retention. See the [runbook](release-runbook.md)
+for emergency version rollback and post-restore verification.
+
+The live verifier compares every served asset to its retained hash, checks
+production robots/headers, redirects, conditional caching and real 404s. Initial
+certificate/asset-readiness probes are bounded and recorded. Live browser checks
+cover onboarding, search, inline source reading and downloads. Final version IDs,
+artifact hashes and results belong in the per-run reports and the persistent
+local record at `scratch/ochat-website-evidence/p11/closeout.json`.
+
+The GitHub repository Website field is updated after live verification; README
+entry points are included in this change. The full Ochat normal/E2E gate remains
+separate todo item 17, not a prerequisite added silently to P11.

--- a/website/planning/release-runbook.md
+++ b/website/planning/release-runbook.md
@@ -8,29 +8,51 @@ current evidence and outstanding gates.
 
 ## One publication owner
 
-GitHub Actions is the intended release owner. The Website workflow runs on every
-pull request and every push to `main`, without path filters. Its OCaml semantic
-job precedes both preview and production website jobs. The final `release-gate`
-requires all jobs to succeed; failure, cancellation, and skipping fail the gate.
-The production job uses a reserved fixture origin for CI qualification only.
+The Website workflow is the sole production publisher for `https://ochatlabs.com`.
+Every pull request and main push runs the OCaml documentation gate and both
+preview/production website matrices. Production builds use the owned origin;
+preview builds remain noindex. The final `release-gate` rejects failed, cancelled
+or skipped prerequisite jobs. The broader Ochat normal/E2E test gate is a separate
+follow-up in scratch/todo.md; do not describe it as already implemented.
 
-The workflow currently has no publication credentials or deploy step. In P11,
-add exactly one trusted publisher requiring `release-gate`, an environment with
-appropriate protection, and the reviewed release record below. Manual accessibility review is deferred from launch by the user. Keep Cloudflare
-Git auto-deployment and alternate production triggers disabled. Untrusted pull
-requests receive no hosting or model credentials. The required check is
-`release-gate` from the GitHub Actions app (ID 15368), as observed on actual runs.
-Main protection requires an up-to-date pull request, applies to administrators,
-blocks force pushes/deletion, and requires conversations to be resolved. The
-sole-maintainer policy requires zero outside approvals. Legacy GitHub Pages
-automatic branch builds are disabled (`build_type: workflow`); no Pages publishing
-workflow exists. See [the enforcement record](p10-github-enforcement.md) for
-actual rejected-push probes, CI results, and the remaining production boundary.
+Only a successful **main push** can enter `deploy-production`, whose GitHub
+`production` environment permits only the `main` branch. Deployment concurrency
+is serialized, and the publisher checks the current main SHA before uploading.
+It downloads `website-production-release` from its own run; it does not rebuild.
+Integrity verification matches the retained file inventory, redirect code,
+Wrangler configuration, package lock, origin, source revision, semantic report,
+search/performance hashes, capacity and browser result. It also checks anonymous
+access to the exact committed first-agent tutorial. `approval.json` combines that
+check with the reviewed historical P10 rehearsal/rollback/enforcement records.
+Those records qualify the procedure; the current candidate is separately tested.
 
-The local opam environment includes pins and is not proof that the clean Ubuntu
-job installs successfully. Resolve failures in the real job with documented,
-reproducible dependencies; never replace it with a success placeholder. Any clean
-CI failure blocks release.
+The only credential-bearing step receives the repository Actions secret
+`CLOUDFLARE_API_TOKEN`. Pull-request builds and tests receive no hosting or model
+credentials. The token's Workers permissions are account-scoped; its zone policy
+is restricted to ochatlabs.com by the owner. Review workflow changes carefully:
+repository administrators can change policies or workflow code, so this is not
+an immutable trust boundary against the owner. Do not enable Cloudflare Git
+builds or another automatic publisher. Legacy GitHub Pages remains workflow-only.
+
+Main protection requires up-to-date PRs, `release-gate` from GitHub Actions app
+15368, resolved conversations, and applies to administrators. Force pushes and
+branch deletion are disabled. No outside approval is required for the sole
+maintainer. Deployment failure is visible as a failed workflow/environment;
+`release-gate` itself reports validation, not post-deployment health.
+
+The main Worker `ochat-website` serves static assets at the apex domain without
+invoking application code. A separate `ochat-website-redirect` Worker redirects
+www to HTTPS apex with path/query preservation and sampled logs/traces. Static
+asset requests do not produce Worker invocation traces. Both configurations and
+the redirect code are retained in the qualified artifact. Enable the zone's
+**Always Use HTTPS** setting for HTTP apex requests. Never point production at
+the noindex `ochat-website-preview` Worker.
+
+Production release artifacts and deployment evidence are retained by GitHub for
+90 days. Download known-good archives to durable storage before retention expires.
+The publisher records existing and resulting Cloudflare deployment versions.
+The first production release has no previous production version; the P10 preview
+rollback is a rehearsal, not a prior production release.
 
 ## Build and retain the candidate
 
@@ -47,7 +69,7 @@ npm run measure:performance
 npm run artifact -- retain ../scratch/release-preview
 ```
 
-The artifact command refuses an existing destination, checks the final tree
+The artifact command also retains the www redirect Worker. It refuses an existing destination, checks the final tree
 against build evidence, and retains `dist/`, reports, the Wrangler configuration,
 and a manifest of file hashes. `verify` rejects changed, additional, or symlinked
 output. Reports include the environment, source revision, origin, lockfile hash,
@@ -215,3 +237,22 @@ account before upload. Sources reviewed on 2026-09-07:
 [redirects](https://developers.cloudflare.com/workers/static-assets/redirects/), and
 [Workers Builds limits](https://developers.cloudflare.com/workers/ci-cd/builds/limits-and-pricing/).
 GitHub owns builds in this design; Cloudflare Workers Builds is not configured.
+
+## Production recovery
+
+Prefer a normal revert PR: revert the faulty website change, let the full gate
+qualify the reverted code at its new main revision, and publish through the same
+workflow. This preserves the single automatic publisher and public source links.
+The pre-deployment versions in `production-deployment-evidence/deployment.json`
+and the prior run's retained archive identify the previous deployment. If an
+emergency manual Cloudflare version rollback is needed, pause automatic releases,
+follow the qualified Wrangler rollback procedure, restore both Workers when both
+changed, verify HTTPS/search/downloads/redirects, and reconcile main before
+resuming automatic publishing. A manual rollback is an explicit incident action,
+not an alternate automatic trigger.
+
+After publication, `rehearse-hosted.mjs` checks exact public bytes for all assets,
+indexing headers, robots, cache validators, 404s, HTTP and www redirects. It records
+bounded initial certificate/asset readiness probes rather than hiding failed
+full checks. Browser onboarding/search/inline-reader checks and domain ownership
+evidence are recorded separately under `scratch/ochat-website-evidence/p11/`.

--- a/website/redirect/worker.mjs
+++ b/website/redirect/worker.mjs
@@ -1,0 +1,12 @@
+// Only the alternate hostname invokes this Worker. The main site stays static.
+export default {
+  fetch(request) {
+    const url = new URL(request.url);
+    if (url.hostname !== 'www.ochatlabs.com')
+      return new Response('Not found', { status: 404 });
+    url.protocol = 'https:';
+    url.hostname = 'ochatlabs.com';
+    url.port = '';
+    return Response.redirect(url.href, 308);
+  },
+};

--- a/website/redirect/wrangler.jsonc
+++ b/website/redirect/wrangler.jsonc
@@ -1,0 +1,15 @@
+{
+  "$schema": "../node_modules/wrangler/config-schema.json",
+  "name": "ochat-website-redirect",
+  "account_id": "ec3ca23aab8456f6369df62e5c6a982c",
+  "main": "worker.mjs",
+  "compatibility_date": "2026-09-08",
+  "workers_dev": false,
+  "preview_urls": false,
+  "routes": [{ "pattern": "www.ochatlabs.com", "custom_domain": true }],
+  "observability": {
+    "enabled": true,
+    "logs": { "enabled": true, "head_sampling_rate": 1 },
+    "traces": { "enabled": true, "head_sampling_rate": 0.01 },
+  },
+}

--- a/website/scripts/publish-production.mjs
+++ b/website/scripts/publish-production.mjs
@@ -1,0 +1,138 @@
+// Called only by the protected main deployment job, after artifact verification.
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { verifyProduction } from './verify-production.mjs';
+import {
+  productionAccount,
+  productionOrigin,
+  productionWorkers,
+} from '../config/production.mjs';
+
+const [directory, semanticFile, output] = process.argv.slice(2);
+if (!directory || !semanticFile || !output)
+  throw new Error(
+    'Usage: publish-production.mjs ARTIFACT SEMANTIC.json REPORT.json',
+  );
+if (
+  process.env.GITHUB_EVENT_NAME !== 'push' ||
+  process.env.GITHUB_REF !== 'refs/heads/main' ||
+  process.env.GITHUB_REPOSITORY !== 'dakotamurphyucf/ochat'
+)
+  throw new Error(
+    'Production publishing requires a main push in the Ochat repository',
+  );
+if (!process.env.CLOUDFLARE_API_TOKEN || !process.env.GITHUB_TOKEN)
+  throw new Error('Deployment credentials missing');
+const artifact = await verifyProduction(
+  path.resolve(directory),
+  path.resolve(semanticFile),
+);
+if (artifact.build.revision !== process.env.GITHUB_SHA)
+  throw new Error('Artifact is not this workflow revision');
+
+const report = {
+  result: 'fail',
+  startedAt: new Date().toISOString(),
+  origin: productionOrigin,
+  revision: artifact.build.revision,
+  artifactSha256: artifact.build.sha256,
+  run: `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`,
+  before: {},
+  after: {},
+};
+async function deployments(worker) {
+  const response = await fetch(
+    `https://api.cloudflare.com/client/v4/accounts/${productionAccount}/workers/scripts/${worker}/deployments`,
+    {
+      headers: { Authorization: `Bearer ${process.env.CLOUDFLARE_API_TOKEN}` },
+      signal: AbortSignal.timeout(30000),
+    },
+  );
+  if (response.status === 404) return { firstDeployment: true };
+  const data = await response.json();
+  if (!response.ok || !data.success)
+    throw new Error(
+      `Cannot read deployment history for ${worker}: HTTP ${response.status}`,
+    );
+  return data.result;
+}
+try {
+  const domainsResponse = await fetch(
+    `https://api.cloudflare.com/client/v4/accounts/${productionAccount}/workers/domains`,
+    {
+      headers: { Authorization: `Bearer ${process.env.CLOUDFLARE_API_TOKEN}` },
+      signal: AbortSignal.timeout(30000),
+    },
+  );
+  const domains = await domainsResponse.json();
+  if (!domainsResponse.ok || !domains.success)
+    throw new Error('Cannot verify existing custom-domain owners');
+  for (const [hostname, service] of [
+    ['ochatlabs.com', 'ochat-website'],
+    ['www.ochatlabs.com', 'ochat-website-redirect'],
+  ]) {
+    const existing = domains.result.find(
+      (domain) => domain.hostname === hostname,
+    );
+    if (existing && existing.service !== service)
+      throw new Error(`Custom domain ${hostname} belongs to another Worker`);
+  }
+  report.previousDomains = domains.result.filter((domain) =>
+    ['ochatlabs.com', 'www.ochatlabs.com'].includes(domain.hostname),
+  );
+  // Serialization prevents overlapping publishers; reject an older queued run.
+  const current = await fetch(
+    `https://api.github.com/repos/${process.env.GITHUB_REPOSITORY}/git/ref/heads/main`,
+    {
+      headers: {
+        Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+        Accept: 'application/vnd.github+json',
+      },
+      signal: AbortSignal.timeout(30000),
+    },
+  );
+  if (
+    !current.ok ||
+    (await current.json()).object.sha !== process.env.GITHUB_SHA
+  )
+    throw new Error('Superseded main revision; refusing deployment');
+  for (const worker of productionWorkers)
+    report.before[worker] = await deployments(worker);
+  for (const args of [
+    [
+      'deploy',
+      '--config',
+      path.resolve(directory, 'wrangler.jsonc'),
+      '--env',
+      'production',
+    ],
+    ['deploy', '--config', path.resolve(directory, 'redirect/wrangler.jsonc')],
+  ]) {
+    const result = spawnSync(
+      process.execPath,
+      ['node_modules/wrangler/bin/wrangler.js', ...args],
+      {
+        stdio: 'inherit',
+        env: {
+          ...process.env,
+          CLOUDFLARE_ACCOUNT_ID: productionAccount,
+          WRANGLER_SEND_METRICS: 'false',
+        },
+      },
+    );
+    if (result.error) throw result.error;
+    if (result.status !== 0)
+      throw new Error(`Wrangler deployment failed (${result.status})`);
+  }
+  for (const worker of productionWorkers)
+    report.after[worker] = await deployments(worker);
+  report.result = 'pass';
+} catch (error) {
+  report.error = error.message;
+  throw error;
+} finally {
+  report.finishedAt = new Date().toISOString();
+  await fs.mkdir(path.dirname(path.resolve(output)), { recursive: true });
+  await fs.writeFile(output, JSON.stringify(report, null, 2) + '\n');
+}

--- a/website/scripts/rehearse-hosted.mjs
+++ b/website/scripts/rehearse-hosted.mjs
@@ -3,6 +3,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { createHash } from 'node:crypto';
 import { verifyArtifact } from './release-artifact.mjs';
+import { productionOrigin } from '../config/production.mjs';
 
 const [directory, output] = process.argv.slice(2);
 if (!directory || !output)
@@ -11,8 +12,15 @@ if (!directory || !output)
   );
 const artifact = await verifyArtifact(path.resolve(directory));
 const origin = new URL(artifact.build.origin);
-if (origin.protocol !== 'https:' || artifact.build.environment !== 'preview')
-  throw new Error('Hosted rehearsal requires an HTTPS preview artifact');
+const production = artifact.build.environment === 'production';
+if (
+  origin.protocol !== 'https:' ||
+  (!production && artifact.build.environment !== 'preview') ||
+  (production && origin.origin !== productionOrigin)
+)
+  throw new Error(
+    'Hosted verification requires an HTTPS preview or the owned production artifact',
+  );
 const headers = await fs.readFile(
   path.join(directory, 'dist/_headers'),
   'utf8',
@@ -24,6 +32,7 @@ const report = {
   artifactSha256: artifact.build.sha256,
   revision: artifact.build.revision,
   baseline,
+  environment: artifact.build.environment,
   scope:
     'Public HTTPS from this machine; exact served bytes, routing, headers and conditional caching. Browser interactions are recorded separately.',
   result: 'fail',
@@ -64,6 +73,37 @@ async function get(route, options = {}) {
   return response;
 }
 try {
+  if (production) {
+    // Initial custom-domain certificates and edge assets may take time to settle.
+    // Preserve each observation; never silently retry a completed verification.
+    report.readiness = [];
+    const homepage = artifact.files.find((file) => file.path === 'index.html');
+    let ready = false;
+    for (let attempt = 0; attempt < 12 && !ready; attempt++) {
+      try {
+        const response = await get('/');
+        ready =
+          response.status === 200 &&
+          hash(Buffer.from(await response.arrayBuffer())) === homepage.sha256;
+        const alternate = await get('https://www.ochatlabs.com/');
+        ready =
+          ready &&
+          alternate.status === 308 &&
+          alternate.headers.get('location') === productionOrigin + '/';
+        report.readiness.push({
+          attempt: attempt + 1,
+          status: response.status,
+          matchingBytes: ready,
+          alternateStatus: alternate.status,
+        });
+      } catch (error) {
+        report.readiness.push({ attempt: attempt + 1, error: error.message });
+      }
+      if (!ready && attempt < 11)
+        await new Promise((resolve) => setTimeout(resolve, 5000));
+    }
+    check(ready, 'Production hostname serves the current artifact over HTTPS');
+  }
   async function checkFile(file) {
     const route = '/' + file.path.replace(/index\.html$/, '');
     const response = await get(route);
@@ -77,8 +117,10 @@ try {
       `${route}: nosniff`,
     );
     check(
-      response.headers.get('x-robots-tag') === 'noindex, nofollow',
-      `${route}: preview indexing header`,
+      production
+        ? !/noindex/i.test(response.headers.get('x-robots-tag') || '')
+        : response.headers.get('x-robots-tag') === 'noindex, nofollow',
+      `${route}: expected environment indexing header`,
     );
     check(
       response.headers.get('x-ochat-rehearsal') ===
@@ -123,10 +165,48 @@ try {
       );
   }
   const robots = await get('/robots.txt');
+  const robotsText = await robots.text();
   check(
-    /Disallow:\s*\//.test(await robots.text()),
-    'robots: disallow crawling',
+    production
+      ? !/^Disallow:\s*\/\s*$/m.test(robotsText) &&
+          robotsText.includes(`Sitemap: ${origin.origin}/sitemap-index.xml`)
+      : /Disallow:\s*\//.test(robotsText),
+    'robots: expected environment crawling policy',
   );
+  if (production) {
+    for (const host of [
+      'http://ochatlabs.com',
+      'http://www.ochatlabs.com',
+      'https://www.ochatlabs.com',
+    ]) {
+      const targetPath = '/docs/start/first-agent/?source=domain-check';
+      const response = await get(host + targetPath);
+      check(
+        [301, 302, 307, 308].includes(response.status),
+        `${host}: redirects to HTTPS canonical host`,
+      );
+      const target = new URL(response.headers.get('location'), host);
+      check(
+        target.protocol === 'https:' &&
+          ['ochatlabs.com', 'www.ochatlabs.com'].includes(target.hostname) &&
+          target.pathname + target.search === targetPath,
+        `${host}: preserves path and query`,
+      );
+      if (target.hostname === 'www.ochatlabs.com') {
+        const next = await get(target.href);
+        check(
+          [301, 302, 307, 308].includes(next.status) &&
+            new URL(next.headers.get('location'), target).href ===
+              origin.origin + targetPath,
+          `${host}: reaches canonical host in at most two redirects`,
+        );
+      } else
+        check(
+          target.href === origin.origin + targetPath,
+          `${host}: exact canonical target`,
+        );
+    }
+  }
   for (const route of [
     '/docs/start/first-agent',
     '/docs/start/first-agent?rehearsal=1',
@@ -170,8 +250,10 @@ try {
       `${route}: exact branded 404`,
     );
     check(
-      response.headers.get('x-robots-tag') === 'noindex, nofollow',
-      `${route}: noindex 404`,
+      production
+        ? !/noindex/i.test(response.headers.get('x-robots-tag') || '')
+        : response.headers.get('x-robots-tag') === 'noindex, nofollow',
+      `${route}: expected environment header (404 HTML noindex is build-validated)`,
     );
   }
   for (const route of [

--- a/website/scripts/release-artifact.mjs
+++ b/website/scripts/release-artifact.mjs
@@ -46,6 +46,11 @@ export async function verifyArtifact(directory) {
     createHash('sha256').update(config).digest('hex') !== manifest.configSha256
   )
     throw new Error('Artifact Wrangler configuration changed');
+  if (manifest.redirect) {
+    const redirect = await inventory(path.join(directory, 'redirect'));
+    if (JSON.stringify(redirect) !== JSON.stringify(manifest.redirect))
+      throw new Error('Artifact redirect Worker changed');
+  }
   return manifest;
 }
 export async function retainArtifact(
@@ -69,6 +74,12 @@ export async function retainArtifact(
     path.join(site, 'wrangler.jsonc'),
     path.join(directory, 'wrangler.jsonc'),
   );
+  await fs.mkdir(path.join(directory, 'redirect'));
+  for (const name of ['worker.mjs', 'wrangler.jsonc'])
+    await fs.copyFile(
+      path.join(site, 'redirect', name),
+      path.join(directory, 'redirect', name),
+    );
   await fs.cp(evidenceDirectory, path.join(directory, 'evidence'), {
     recursive: true,
     filter: (source) =>
@@ -89,6 +100,7 @@ export async function retainArtifact(
           .update(await fs.readFile(path.join(site, 'package-lock.json')))
           .digest('hex'),
         files: actual.files,
+        redirect: await inventory(path.join(directory, 'redirect')),
       },
       null,
       2,

--- a/website/scripts/verify-production.mjs
+++ b/website/scripts/verify-production.mjs
@@ -1,0 +1,128 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { verifyArtifact } from './release-artifact.mjs';
+import { checkApproval } from './release-approval.mjs';
+import { productionOrigin } from '../config/production.mjs';
+
+const site = fileURLToPath(new URL('../', import.meta.url));
+const read = async (filename) =>
+  JSON.parse(await fs.readFile(filename, 'utf8'));
+const sha = (bytes) => createHash('sha256').update(bytes).digest('hex');
+
+export function checkQualification(
+  artifact,
+  semantic,
+  search,
+  performance,
+  capacity,
+  browser,
+  revision,
+) {
+  assert.equal(artifact.build.result, 'pass');
+  assert.equal(artifact.build.environment, 'production');
+  assert.equal(artifact.build.origin, productionOrigin);
+  assert.equal(artifact.build.revision, revision);
+  assert.equal(semantic.result, 'pass');
+  assert.equal(semantic.revision, revision);
+  for (const report of [search, performance]) {
+    assert.equal(report.result, 'pass');
+    assert.equal(report.artifactSha256, artifact.build.sha256);
+  }
+  assert.equal(search.environment, 'production');
+  assert.equal(capacity.result, 'pass');
+  assert.equal(browser.status, 'passed');
+  assert.deepEqual(browser.failedTests, []);
+}
+
+export async function verifyProduction(directory, semanticFile) {
+  const artifact = await verifyArtifact(directory);
+  const revision = execFileSync('git', ['rev-parse', 'HEAD'], {
+    cwd: site,
+    encoding: 'utf8',
+  }).trim();
+  const evidence = path.join(directory, 'evidence');
+  checkQualification(
+    artifact,
+    await read(semanticFile),
+    await read(path.join(evidence, 'search-report.json')),
+    await read(path.join(evidence, 'performance-report.json')),
+    await read(path.join(evidence, 'capacity-report.json')),
+    await read(path.join(directory, 'browser-result.json')),
+    revision,
+  );
+  assert.equal(
+    artifact.configSha256,
+    sha(await fs.readFile(path.join(site, 'wrangler.jsonc'))),
+  );
+  assert.equal(
+    artifact.packageLockSha256,
+    sha(await fs.readFile(path.join(site, 'package-lock.json'))),
+  );
+  assert.ok(
+    artifact.redirect,
+    'Production requires a retained redirect Worker',
+  );
+  assert.deepEqual(
+    artifact.redirect.files.map((f) => f.path),
+    ['worker.mjs', 'wrangler.jsonc'],
+  );
+  for (const name of ['worker.mjs', 'wrangler.jsonc'])
+    assert.deepEqual(
+      await fs.readFile(path.join(directory, 'redirect', name)),
+      await fs.readFile(path.join(site, 'redirect', name)),
+    );
+  // Check a real anonymous source URL at this exact public revision.
+  const source = 'docs-src/agent-server/tutorials/local-tui.md';
+  const url = `https://raw.githubusercontent.com/dakotamurphyucf/ochat/${revision}/${source}`;
+  const response = await fetch(url, { signal: AbortSignal.timeout(30000) });
+  assert.equal(response.status, 200, 'Public committed tutorial must resolve');
+  assert.deepEqual(
+    Buffer.from(await response.arrayBuffer()),
+    await fs.readFile(path.join(site, '..', source)),
+  );
+  const approval = {
+    artifactSha256: artifact.build.sha256,
+    origin: artifact.build.origin,
+    revision,
+    reviews: {
+      ...(await read(path.join(site, 'config/release-prerequisites.json'))),
+      publicSourceCommit: {
+        status: 'pass',
+        reviewer: 'Automated anonymous source-byte check',
+        reviewedAt: new Date().toISOString(),
+        evidence: url,
+      },
+    },
+  };
+  assert.equal(checkApproval(artifact, approval).result, 'pass');
+  await fs.writeFile(
+    path.join(directory, 'approval.json'),
+    JSON.stringify(approval, null, 2) + '\n',
+  );
+  return artifact;
+}
+
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  const [directory, semantic] = process.argv.slice(2);
+  if (!directory || !semantic)
+    throw new Error('Usage: verify-production.mjs ARTIFACT SEMANTIC.json');
+  const artifact = await verifyProduction(
+    path.resolve(directory),
+    path.resolve(semantic),
+  );
+  console.log(
+    JSON.stringify({
+      result: 'pass',
+      revision: artifact.build.revision,
+      origin: artifact.build.origin,
+      sha256: artifact.build.sha256,
+    }),
+  );
+}

--- a/website/tests/deployment.test.mjs
+++ b/website/tests/deployment.test.mjs
@@ -16,6 +16,8 @@ import {
   checkApproval,
   requiredReviews,
 } from '../scripts/release-approval.mjs';
+import { checkQualification } from '../scripts/verify-production.mjs';
+import redirectWorker from '../redirect/worker.mjs';
 
 test('public promotion honors the manual-review deferral and rejects incomplete hosted checks or stale evidence', () => {
   const artifact = {
@@ -143,11 +145,17 @@ test('retained artifact verification rejects changed, additional and symlinked o
     await fs.mkdir(path.join(directory, 'dist'));
     await fs.writeFile(path.join(directory, 'dist/index.html'), 'known good');
     await fs.writeFile(path.join(directory, 'wrangler.jsonc'), '{}');
+    await fs.mkdir(path.join(directory, 'redirect'));
+    await fs.writeFile(
+      path.join(directory, 'redirect/worker.mjs'),
+      'original redirect',
+    );
     const actual = await inventory(path.join(directory, 'dist'));
     const manifest = {
       build: { sha256: actual.sha256 },
       files: actual.files,
       configSha256: createHash('sha256').update('{}').digest('hex'),
+      redirect: await inventory(path.join(directory, 'redirect')),
     };
     await fs.writeFile(
       path.join(directory, 'artifact.json'),
@@ -162,7 +170,128 @@ test('retained artifact verification rejects changed, additional and symlinked o
     await fs.unlink(path.join(directory, 'dist/extra.html'));
     await fs.symlink('index.html', path.join(directory, 'dist/link.html'));
     await assert.rejects(verifyArtifact(directory), /symlink/);
+    await fs.unlink(path.join(directory, 'dist/link.html'));
+    await fs.writeFile(
+      path.join(directory, 'redirect/worker.mjs'),
+      'changed redirect',
+    );
+    await assert.rejects(verifyArtifact(directory), /redirect Worker changed/);
   } finally {
     await fs.rm(directory, { recursive: true, force: true });
   }
+});
+
+test('production publishing is main-only, serialized, gated, and uses the tested artifact', async () => {
+  const workflow = parse(
+    await fs.readFile(
+      new URL('../../.github/workflows/website.yml', import.meta.url),
+      'utf8',
+    ),
+  );
+  const publish = workflow.jobs['deploy-production'];
+  assert.deepEqual(publish.needs, ['release-gate']);
+  assert.equal(
+    publish.if,
+    "github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.release-gate.result == 'success'",
+  );
+  assert.equal(publish.environment.name, 'production');
+  assert.equal(publish.concurrency['cancel-in-progress'], false);
+  assert.equal(workflow.permissions.contents, 'read');
+  assert.deepEqual(Object.keys(workflow.on).sort(), ['pull_request', 'push']);
+  assert.ok(
+    publish.steps.some(
+      (step) =>
+        step.uses === 'actions/download-artifact@v4' &&
+        step.with.name === 'website-production-release',
+    ),
+  );
+  assert.ok(
+    !publish.steps.some((step) => /npm run build/.test(step.run || '')),
+  );
+  const secrets = Object.values(workflow.jobs)
+    .flatMap((job) => job.steps || [])
+    .filter((step) =>
+      JSON.stringify(step).includes('secrets.CLOUDFLARE_API_TOKEN'),
+    );
+  assert.equal(secrets.length, 1);
+  assert.equal(secrets[0].name, 'Publish qualified release');
+});
+
+test('production qualification rejects stale, preview, failed, or mismatched evidence', () => {
+  const revision = 'a'.repeat(40);
+  const build = {
+    result: 'pass',
+    environment: 'production',
+    origin: 'https://ochatlabs.com',
+    revision,
+    sha256: 'b'.repeat(64),
+  };
+  const good = [
+    { build },
+    { result: 'pass', revision },
+    { result: 'pass', environment: 'production', artifactSha256: build.sha256 },
+    { result: 'pass', artifactSha256: build.sha256 },
+    { result: 'pass' },
+    { status: 'passed', failedTests: [] },
+    revision,
+  ];
+  checkQualification(...good);
+  for (const mutate of [
+    (args) => {
+      args[0].build.environment = 'preview';
+    },
+    (args) => {
+      args[0].build.origin = 'https://release.ochat.test';
+    },
+    (args) => {
+      args[0].build.revision = 'c'.repeat(40);
+    },
+    (args) => {
+      args[1].result = 'fail';
+    },
+    (args) => {
+      args[1].revision = 'c'.repeat(40);
+    },
+    (args) => {
+      args[2].artifactSha256 = 'c'.repeat(64);
+    },
+    (args) => {
+      args[3].result = 'fail';
+    },
+    (args) => {
+      args[4].result = 'fail';
+    },
+    (args) => {
+      args[5].failedTests = ['broken-test'];
+    },
+    (args) => {
+      args[5].status = 'failed';
+    },
+  ]) {
+    const args = structuredClone(good);
+    mutate(args);
+    assert.throws(() => checkQualification(...args));
+  }
+});
+
+test('www redirect preserves encoded paths and query strings and rejects unrelated hosts', () => {
+  for (const scheme of ['http:', 'https:'])
+    for (const route of [
+      '/',
+      '/docs/start/first-agent/?q=a%2Fb&x=two+words',
+      '/downloads/a%20b.chatmd',
+    ]) {
+      const response = redirectWorker.fetch(
+        new Request(`${scheme}//www.ochatlabs.com${route}`),
+      );
+      assert.equal(response.status, 308);
+      assert.equal(
+        response.headers.get('location'),
+        `https://ochatlabs.com${route}`,
+      );
+    }
+  assert.equal(
+    redirectWorker.fetch(new Request('https://unrelated.example/')).status,
+    404,
+  );
 });

--- a/website/wrangler.jsonc
+++ b/website/wrangler.jsonc
@@ -8,6 +8,13 @@
     "html_handling": "auto-trailing-slash",
   },
   "env": {
+    "production": {
+      "name": "ochat-website",
+      "account_id": "ec3ca23aab8456f6369df62e5c6a982c",
+      "workers_dev": false,
+      "preview_urls": false,
+      "routes": [{ "pattern": "ochatlabs.com", "custom_domain": true }],
+    },
     "preview": {
       "name": "ochat-website-preview",
       "account_id": "ec3ca23aab8456f6369df62e5c6a982c",


### PR DESCRIPTION
The documentation website now has an owned production address, https://ochatlabs.com. Build production metadata for that origin and publish the exact qualified artifact after the required main release gate passes. A separate small Worker redirects www to the HTTPS apex while preserving paths and query strings.

The main-only production environment and serialized publisher reject stale revisions, mismatched artifacts/configuration, failed semantic/browser/search/performance evidence, and conflicting Worker domain ownership. Retain release archives and before/after deployment versions, verify public source bytes, and check all hosted asset bytes, headers, redirects and 404s after publishing. Add the website and onboarding links to the README and document deployment/recovery.

Validation: 71 local unit tests and Astro diagnostics pass; the redirect passes unit checks, local Cloudflare runtime path/query checks, and Wrangler dry-run packaging. GitHub run [34181349213](https://github.com/dakotamurphyucf/ochat/actions/runs/34181349213) passed the semantic gate (308 pages/38 methods), both website matrices (256 browser passes and two existing skips each), and release-gate. Both environments passed unit, build, search, and performance checks. The downloaded production artifact passed exact-commit qualification and file verification for https://ochatlabs.com. Production deployment follows the protected merge and a successful main run. The broader Ochat normal/E2E test gate remains a separate todo item.
