### PR TITLE
Finish website maintenance handoff and fix launch verification issues

### DIFF
--- a/website/CONTRIBUTING.md
+++ b/website/CONTRIBUTING.md
@@ -1,0 +1,160 @@
+# Contributing to the Ochat website
+
+Start here for a routine edit. The [website README](README.md) explains the
+importer, source readers, search and rendering internals. The
+[release runbook](planning/release-runbook.md) owns publication and recovery;
+[maintenance](planning/maintenance.md) records owners, review dates and backlog.
+
+## First edit from a clean checkout
+
+```sh
+git clone https://github.com/dakotamurphyucf/ochat.git
+cd ochat
+git switch -c docs/my-change
+cd website
+nvm use
+npm ci
+npm run dev
+```
+
+Use Node 22.22.1 from `.nvmrc`; another Node version manager is fine. Read the
+printed preview URL: the server starts at port 4321 and selects another port
+when it is occupied. Keep this terminal running while editing. No model keys
+or OCaml installation are needed for the website preview.
+
+For an initial exercise, edit a prose sentence in
+`docs-src/agent-server/tutorials/local-tui.md` and visit
+`/docs/start/first-agent/`. The watcher regenerates source input and restarts
+the reader; reload after it reports ready. The page's edit link points to that
+original Markdown file on GitHub. Its committed-source link identifies the
+checkout's HEAD, so it does not include an uncommitted local edit. New files
+cannot have a working public source link before they are committed and pushed.
+
+Stop the dev process before running generation or build checks in that checkout:
+
+```sh
+npm run check
+npm run build
+npm run preview
+```
+
+Search needs a built Pagefind index; the dev server alone is not a complete
+search test. Do not run `content`, `check` and `build` concurrently: they write
+the same generated snapshot. An invalid source stops the dev supervisor with
+an error; fix the input and restart `npm run dev`.
+
+Review `git diff`, stage only intended source files, commit and open a PR.
+Generated output stays ignored. Production requires committed source bytes
+and public revision links; use the protected workflow for publication.
+
+## Find the source of a change
+
+| Change | Source of truth |
+| --- | --- |
+| Article prose | `docs-src/`; find its `source` in `config/docs-manifest.json` |
+| Code-generated reference prose | The existing OCaml generator identified by the manifest's `generatedBy`; regenerate through its documented Dune target |
+| Title, description, route, publication/indexing status | `config/docs-manifest.json` |
+| Sidebar and Start here groups | `config/navigation.mjs` and manifest section/order fields |
+| Tutorial sequence and example associations | `config/tutorials.json` |
+| Homepage copy and layout | `src/pages/index.astro` and its imported components; the hero ChatMD comes from root `Readme.md` |
+| Application guides and recorded workflow | `docs-src/applications/`, `config/applications.json`, and the selected canonical example/recording files |
+| ChatMD/ChatML source and downloads | `docs-src/examples/catalog.json`, its exact files, and `config/supplemental-sources.json` |
+| Themes, typography, shared UI | `src/styles/tokens.css`, other `src/styles/`, and `src/components/` |
+| Images, fonts and license notices | `public/`, `config/media.json`, and approved repository mappings in `config/assets.json` |
+| Search ranking and regression queries | `config/search.mjs`, `config/search-queries.json`, and `scripts/search-index.mjs` |
+| Sitemap/social metadata | `config/presentation.mjs`, manifest policy and `config/site.mjs` |
+| HTTP headers and asset routing | `scripts/deployment-policy.mjs` and `wrangler.jsonc` |
+| www-to-apex redirect | `redirect/worker.mjs` and `redirect/wrangler.jsonc` |
+| Requirements, operations and evidence summaries | `planning/`; implementation memory stays in ignored `scratch/` |
+
+Never hand-edit `.generated/`, `.astro/`, `dist/`, or Dune's `_build/` output.
+Planning documents are repository documentation and are not served by the site.
+
+## Add a page
+
+1. Write original Markdown under `docs-src/` and stage it with Git; the importer
+   inventories tracked/staged sources. Copy the structure of a nearby manifest
+   entry, giving the new page a unique ID and the exact repository-relative source.
+2. Assign a disposition. A published page needs a unique lowercase `/docs/…/`
+   route, useful title/description, appropriate section/order and explicit
+   navigation/search/sitemap/noindex settings. Use existing audience, kind,
+   status and provenance values from `scripts/manifest-schema.mjs`.
+3. Add navigation or tutorial/application associations when appropriate. Related
+   targets use manifest IDs. Keep source-relative Markdown links; the importer
+   resolves approved destinations. Add useful image descriptions and language
+   labels on code fences (`chatml` uses OCaml highlighting).
+4. Run the checks below. Review `.generated/migration-report.md` for inclusion
+   and deferral reasons and `.generated/content-report.json` for provenance.
+   Do not invent a verification date or call an example live-checked without
+   execution evidence for its actual inputs.
+
+## Remove or move a page
+
+Decide whether the old URL should remain a compatibility/bridge page or needs
+an explicit redirect. Update incoming links, related IDs, tutorial/application
+associations, navigation and search benchmarks. Preserve established heading
+anchors with a reviewed `fragmentAliases` mapping when headings change.
+Do not delete an entire manifest entry while leaving its canonical source
+unaccounted for; choose `repository-only` or `deferred` where appropriate.
+
+There is currently no authored path-redirect registry. The `aliases` field is
+not an implemented redirect mechanism. Prefer an explicit bridge page for a
+routine move. If a real HTTP redirect is needed, add reviewed generation of
+`_redirects` to the authored build pipeline, including source/provenance and
+capacity handling; do not hand-edit `dist/_redirects`. Validate old/new paths,
+fragments, queries, loops and chains in the deployed environment. Host redirects
+belong to the separate www Worker, not a static path rule.
+
+## Update an example or capture
+
+Edit canonical files and reconcile catalog entrypoint, companions, dependency
+edges, exact download approvals, prerequisites and licenses. Readers and `.tar`
+downloads must retain the original full text and relative filenames. Run the
+offline semantic documentation checks before refreshing verification hashes.
+Changing a recorded input without rerunning its actual verification must leave
+the example visibly not checked.
+
+`scripts/record-showcase.py` overwrites the tracked showcase with scripted data
+by default; `--live` makes paid provider calls. Do not run it as a routine build
+or replace the real capture to clear stale verification. An intentional capture
+update needs its own reviewed inputs, provenance and bounded execution scope.
+
+## Choose validation appropriate to the edit
+
+| Edit | Local validation before the full PR gate |
+| --- | --- |
+| Prose/metadata/navigation | `npm run check`, `npm run build`, inspect the edited route and source link |
+| Tutorial, tool/runtime contract, selected example | Above plus `opam exec -- dune build --force @agent-docs-check` from the repository root |
+| Search or changes to discoverability | Build, then `npm run evaluate:search` |
+| UI, CSS, templates or browser behavior | Build, install browsers, then `npm run test:browser -- --workers=2`; also `npm run measure:performance` for affected presentation |
+| Hosting, headers, redirects or downloads | Retain the qualified artifact and follow the runbook's local/hosted routing checks |
+| Planning-only documentation | Check referenced paths/commands and `git diff --check`; current GitHub policy still runs the full gate |
+
+Install browser binaries with
+`npx playwright install chromium firefox webkit` (Linux runners also need the
+supported system dependencies via `--with-deps`). Search and performance scripts
+start their own temporary previews. For a subset of browser tests, choose an
+existing relevant file/test; that does not replace full release qualification.
+The semantic gate uses the project's qualified OCaml setup and pins from the
+runbook, not a website-installed compiler. It makes no provider calls.
+
+## Upgrade dependencies
+
+Use a dedicated branch. Review official release notes and the current
+Node/framework compatibility requirements; keep exact package versions and
+commit the resulting `package-lock.json`. Keep Astro/Starlight integration,
+Pagefind ownership, Shiki grammars, Satori/Sharp output, Wrangler schema and the
+scoped `fflate` override in the review. Upgrade only the intended packages.
+Use `npm ci` in a fresh checkout to demonstrate the lockfile, then run the full
+affected build/browser/search/performance/hosting checks. Record cold and warm
+results when changing cache/toolchain behavior; do not silently reuse old
+artifact evidence. Tasks 17–19 cover future gate improvements separately.
+
+## Optional generated API reference
+
+API hosting is deferred. For local investigation use the Ochat toolchain and
+`opam exec -- dune build @doc`; inspect `_build/default/_doc/_html/` locally.
+Do not copy it into `dist/`, change the exclusion flag, or expose `/api/` alone.
+Reopening hosting requires the link/scope/license/search/assembly work listed
+in [the P09 review](planning/p09-completion-review.md). The regular prose site
+continues to build without OCaml.

--- a/website/README.md
+++ b/website/README.md
@@ -2,7 +2,7 @@
 
 Production domain: **https://ochatlabs.com**. The protected Website workflow builds for this origin, retains the tested artifact, and publishes only after the main release gate passes. See [the production launch record](planning/p11-launch.md) and [release runbook](planning/release-runbook.md).
 
-A static Astro/Starlight website with an application-led homepage and repository-owned documentation. Six application guides, an inspectable recorded workflow, and a ten-lesson curriculum help readers discover and build useful agents. The catalog contains fourteen entries: eight complete examples, five configurable templates, and one illustrative reading sample. The preview renders 123 documentation routes and accounts for 308 canonical documents (110 published, 4 compatibility, 9 bridges, 175 repository-only, 10 deferred). Search covers 114 approved pages with 21 benchmark queries. See [the application UI review](planning/application-ui-review.md) for current scope and verification. P09 is complete through user-confirmed API-reference deferral; P10 and Milestone C are complete within the approved launch scope: local qualification, hosted preview rehearsal/rollback, and actual GitHub release enforcement pass; manual accessibility review remains explicitly deferred. P11 production launch is next. See [the P10 review](planning/p10-completion-review.md).
+A static Astro/Starlight website with an application-led homepage and repository-owned documentation. Six application guides, an inspectable recorded workflow, and a ten-lesson curriculum help readers discover and build useful agents. The catalog contains fourteen entries: eight complete examples, five configurable templates, and one illustrative reading sample. The preview renders 123 documentation routes and accounts for 308 canonical documents (110 published, 4 compatibility, 9 bridges, 175 repository-only, 10 deferred). Search covers 114 approved pages with 21 benchmark queries. See [the application UI review](planning/application-ui-review.md) for current scope and verification. P09 is complete through user-confirmed API-reference deferral; P10 and Milestone C are complete within the approved launch scope: local qualification, hosted preview rehearsal/rollback, and actual GitHub release enforcement pass; manual accessibility review remains explicitly deferred. P11 public launch is verified at https://ochatlabs.com; registrar contact-email confirmation remains owner-managed. See [contributor workflows](CONTRIBUTING.md) and [maintenance ownership and follow-ups](planning/maintenance.md). See [the P10 review](planning/p10-completion-review.md).
 
 ## Run locally
 
@@ -35,7 +35,7 @@ npm run evaluate:search
 npm run test:browser
 ```
 
-The browser suite includes search, themes, mobile navigation/overflow, accessibility checks, source links, no-JavaScript reading, and exact clipboard bytes in Chromium. Hosted headers/routing are separate release checks; Astro preview does not establish Cloudflare behavior. The Linux CI workflow is configured to run the locked build and browser suite; its remote run is still pending. Run `dune build @agent-docs-check` from the repository root when technical docs/examples change; this independent offline semantic gate remains necessary.
+The browser suite includes search, themes, mobile navigation/overflow, accessibility checks, source links, no-JavaScript reading, and exact clipboard bytes in Chromium. Hosted headers/routing are separate release checks; Astro preview does not establish Cloudflare behavior. The Linux CI workflow runs the locked build and browser suite; its actual passing runs and production deployment are recorded in [the launch record](planning/p11-launch.md). Run `dune build @agent-docs-check` from the repository root when technical docs/examples change; this independent offline semantic gate remains necessary.
 
 ## Where changes belong
 
@@ -70,7 +70,7 @@ The homepage ChatMD comes from the first XML example in the root README. Its lau
 
 Default builds use `http://localhost:4321`, preview noindex metadata/headers, and a crawl-disallowing robots file. `SITE_URL` controls the origin; `SITE_ENV=production` requires an explicit HTTPS origin. A production build must be generated and checked again after domain ownership is established. Do not deploy a localhost-origin preview as production.
 
-`wrangler.jsonc` configures Workers Static Assets and an explicit `preview` environment for the owner’s account and `ochat-website-preview` Worker. It contains no credentials or custom domain. `dist/` is the only deployable directory. Local checks and the [hosted rehearsal/rollback](planning/p10-hosted-rehearsal.md) pass. The [release runbook](planning/release-runbook.md) records the enforced GitHub gate and P11 production-publishing requirements. Keep alternate deployment triggers disabled.
+`wrangler.jsonc` configures Workers Static Assets with separate `preview` and `production` environments. Production attaches `ochatlabs.com` to `ochat-website`; `redirect/wrangler.jsonc` attaches `www.ochatlabs.com` to the redirect Worker. Configuration contains public identifiers, never credentials. `dist/` is the only static-asset directory; the qualified release separately retains the redirect Worker and deployment evidence. Local checks and the [hosted rehearsal/rollback](planning/p10-hosted-rehearsal.md) pass. The [release runbook](planning/release-runbook.md) records the enforced GitHub gate, current production publisher, and recovery procedure. Keep alternate deployment triggers disabled.
 
 The complete source inventory and deferral reasons are regenerated in `.generated/migration-report.json` and `.generated/migration-report.md`. They remain outside `dist/` and are uploaded as CI evidence. Published content/provenance is reported in `.generated/content-report.json`; output sizes and artifact SHA-256 are in `.generated/build-evidence.json`. The tutorial/example verification and download inventory is `.generated/examples-report.json`. These reports describe the local build and are not proof of live-runtime correctness or domain ownership. Immutable view-source links identify the Git HEAD snapshot; uncommitted changes can differ and must be recorded during development.
 
@@ -107,6 +107,10 @@ renderer is an optional download, excluded from the eager page budget.
 
 ## Visual and keyboard review
 
+Optional Astro page prefetching is disabled in `astro.config.mjs`: rapid navigation
+reproduced cancelled-prefetch errors in WebKit. Links use ordinary browser
+navigation; the separate on-demand search worker/index remains enabled.
+
 With the built local preview running, run `npm run review:design` from
 `website/`. It captures the homepage, first-agent tutorial and ChatML reference
 at desktop/mobile widths in both themes, measures actual text/focus contrast,
@@ -126,7 +130,7 @@ menu focus/return, search, contents links, code/table scrolling, reduced motion,
 forced-color controls, copy success/failure and no-JavaScript navigation. On
 macOS WebKit, Option+Tab follows the browser's all-links keyboard mode. These
 checks are not a screen-reader assessment or a claim that native browser zoom
-and mobile software keyboards have been reviewed. Those remain release checks.
+and mobile software keyboards have been reviewed. Manual assistive-technology and physical-device reviews remain explicitly deferred from launch; see the maintenance backlog.
 
 ## Tutorial, source reader, and download maintenance
 
@@ -156,8 +160,7 @@ containment, copies exact bytes into the same generated snapshot as the pages,
 and produces deterministic `.tar` bundles with original relative filenames.
 Individual extensionless files use a `.txt` URL for static hosting; their download
 attribute and archive preserve names such as `dune`. Plain `.tar` avoids automatic HTTP decompression and browser recompression
-behavior encountered with gzip archive extensions. Hosted response behavior still needs
-the P10/P11 release check. No source bundle is an executable website action.
+behavior encountered with gzip archive extensions. Hosted response behavior is checked by the P10/P11 release verifier and must be rechecked when download packaging or hosting changes. No source bundle is an executable website action.
 
 Run `dune build --force @agent-docs-check` after changing selected source files or
 tutorials. It checks actual captured dependency loading, missing companions, file
@@ -315,19 +318,17 @@ The CI workflow runs this prerequisite before preview and production website
 jobs and has no input path filters. Its final gate rejects failed, skipped and
 cancelled prerequisites. Actual clean GitHub execution and strict main protection are verified in
 [the enforcement record](planning/p10-github-enforcement.md). Main requires
-`release-gate` from GitHub Actions, including for administrators. Production
-publishing remains disabled until P11 connects the owned origin and trusted publisher.
+`release-gate` from GitHub Actions, including for administrators. Production publishing is enabled only after the passing main release gate, using that run’s retained artifact.
 
 `npm run artifact -- retain DIRECTORY` saves a verified output manifest;
 `npm run artifact -- verify DIRECTORY` checks retained bytes.
 `npm run rehearse:static -- REPORT.json ARTIFACT [ARTIFACT ...]` exercises the
 pinned local Workers runtime and can restore a previous retained artifact.
-`npm run rehearse:hosted -- ARTIFACT REPORT.json` checks a retained preview
-against its public HTTPS origin without deploying or changing remote state.
+`npm run rehearse:hosted -- ARTIFACT REPORT.json` checks a retained HTTPS preview or owned production artifact
+against its public origin without deploying or changing remote state.
 `npm run release:ready -- ARTIFACT APPROVAL.json` rejects fixture origins,
 stale approvals and incomplete hosted release records.
 
 See [the release runbook](planning/release-runbook.md),
 [manual accessibility worksheet](planning/manual-accessibility-review.md), and
-[P10 qualification record](planning/p10-completion-review.md). Local candidate
-and public deployment are distinct; P11 has not started.
+[P10 qualification record](planning/p10-completion-review.md). Local candidate and public deployment evidence remain distinct. The [P11 launch record](planning/p11-launch.md) identifies the first verified production release; [maintenance](planning/maintenance.md) owns ongoing reviews.

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -22,6 +22,9 @@ export default defineConfig({
   site: origin,
   markdown: { processor: unified({ rehypePlugins: [readingAccessibility] }) },
   output: 'static',
+  // Starlight otherwise enables speculative fetches on link hover/focus.
+  // Keep native navigation: cancelled prefetches report errors in WebKit.
+  prefetch: false,
   trailingSlash: 'always',
   publicDir: './.generated/public',
   integrations: [

--- a/website/planning/implementation-spec.md
+++ b/website/planning/implementation-spec.md
@@ -2017,18 +2017,20 @@ Ordered tasks:
 
 Ordered tasks:
 
-- [ ] **P11.01 — Confirm the domain purchase details.** Check actual availability, full purchase/renewal price, required term, and owning account for the selected candidate.
+- [x] **P11.01 — Confirm the domain purchase details.** Check actual availability, full purchase/renewal price, required term, and owning account for the selected candidate.
 - [ ] **P11.02 — Register or connect the domain.** Complete the intended registrar operation and required ownership/email verification; record renewal ownership and DNS configuration.
-- [ ] **P11.03 — Attach the production custom domain.** Follow the hosting platform's supported flow, verify certificates, and establish canonical-host redirects where applicable.
-- [ ] **P11.04 — Finalize production configuration.** Set the owned site origin, regenerate canonical metadata and sitemaps, remove preview noindex behavior, and run the checks affected by these changes.
-- [ ] **P11.05 — Publish the verified production artifact.** Use the designated deployment owner and retain the prior known-good artifact and revision for rollback.
-- [ ] **P11.06 — Verify the live site.** Test homepage, first-agent path, representative nested docs, search, downloads, optional API content, alternate-host redirects, and real 404 responses over HTTPS.
-- [ ] **P11.07 — Update GitHub entry points.** Set the repository Website field, add the prominent README docs link, and verify reciprocal repository links and source-edit destinations.
-- [ ] **P11.08 — Record Milestone D.** Capture the canonical URL, deployment revision, live verification results, ownership details, and any intentionally deferred features.
+- [x] **P11.03 — Attach the production custom domain.** Follow the hosting platform's supported flow, verify certificates, and establish canonical-host redirects where applicable.
+- [x] **P11.04 — Finalize production configuration.** Set the owned site origin, regenerate canonical metadata and sitemaps, remove preview noindex behavior, and run the checks affected by these changes.
+- [x] **P11.05 — Publish the verified production artifact.** Use the designated deployment owner and retain the prior known-good artifact and revision for rollback.
+- [x] **P11.06 — Verify the live site.** Test homepage, first-agent path, representative nested docs, search, downloads, optional API content, alternate-host redirects, and real 404 responses over HTTPS.
+- [x] **P11.07 — Update GitHub entry points.** Set the repository Website field, add the prominent README docs link, and verify reciprocal repository links and source-edit destinations.
+- [x] **P11.08 — Record Milestone D.** Capture the canonical URL, deployment revision, live verification results, ownership details, and any intentionally deferred features.
 
 **Deliverables:** Working custom-domain website, updated GitHub discovery links, live verification record, and recoverable production deployment.
 
 **Completion gate:** A visitor can reach the live site from GitHub and complete the first-agent reading path. The domain, canonical metadata, search, redirects, and published artifacts agree. A build on a temporary hostname alone does not complete this phase.
+
+**P11 launch checkpoint (2026-09-08 UTC):** Milestone D's public launch is verified at https://ochatlabs.com. PR #21 merged at `b859aef70312a0f2553998a024f3c98561906106`; main run 34182707554 passed the release gate and deployment attempt 2 passed 3,601 hosted assertions. The failed first domain attachment was resolved by removing conflicting DNS records and retrying only deployment with the same qualified artifact. Final live checks passed 21 flows across three browsers, including inline ChatMD, search and first-agent onboarding. GitHub's Website field and README entry points are updated. P11.02 remains administratively open only for unconfirmed registrar contact-email verification; domain registration, DNS connection and HTTPS are verified. The $45 renewal quote's period remains unspecified. P09 API hosting and P10.03 manual accessibility remain deferred. An intermittent initial WebKit prefetch diagnostic is retained for P12 monitoring; subsequent diagnostic and uninstrumented browser checks passed unchanged bytes. See [the launch record](p11-launch.md) for release/version IDs, recovery baseline and evidence. Tasks 17–19 remain future gate enhancements.
 
 ### 19.20 Phase P12 — Complete maintenance handoff and post-launch follow-through
 
@@ -2038,13 +2040,13 @@ Ordered tasks:
 
 Ordered tasks:
 
-- [ ] **P12.01 — Finish contributor documentation.** Explain where article prose, homepage content, metadata, navigation, examples, assets, and redirect rules are edited.
-- [ ] **P12.02 — Document routine changes.** Cover adding/removing a page, changing a route, updating an example, upgrading dependencies, and regenerating optional API output.
-- [ ] **P12.03 — Validate a contributor workflow.** From a clean checkout, edit one source page, preview it, run relevant checks, and confirm the source-edit link points to the right file.
-- [ ] **P12.04 — Finalize operational ownership.** Record domain renewal, account recovery ownership, deployment responsibility, and rollback instructions without putting credentials in repository documentation.
+- [x] **P12.01 — Finish contributor documentation.** Explain where article prose, homepage content, metadata, navigation, examples, assets, and redirect rules are edited.
+- [x] **P12.02 — Document routine changes.** Cover adding/removing a page, changing a route, updating an example, upgrading dependencies, and regenerating optional API output.
+- [x] **P12.03 — Validate a contributor workflow.** From a clean checkout, edit one source page, preview it, run relevant checks, and confirm the source-edit link points to the right file.
+- [x] **P12.04 — Finalize operational ownership.** Record domain renewal, account recovery ownership, deployment responsibility, and rollback instructions without putting credentials in repository documentation.
 - [ ] **P12.05 — Check initial production behavior.** Inspect available deployment/error evidence and revisit principal routes, search, downloads, and indexing headers after launch; fix concrete defects found.
-- [ ] **P12.06 — Create a prioritized follow-up backlog.** Carry forward specific deferred pages, optional API work, search limitations, accessibility findings, and media improvements with their rationale.
-- [ ] **P12.07 — Schedule appropriate later reviews.** Assign ownership for content freshness, external-link checks, framework upgrades, and a later usability/performance review when useful traffic or feedback exists.
+- [x] **P12.06 — Create a prioritized follow-up backlog.** Carry forward specific deferred pages, optional API work, search limitations, accessibility findings, and media improvements with their rationale.
+- [x] **P12.07 — Schedule appropriate later reviews.** Assign ownership for content freshness, external-link checks, framework upgrades, and a later usability/performance review when useful traffic or feedback exists.
 - [ ] **P12.08 — Close the implementation record.** Mark completed phases with evidence, retain explicit deferred scope, and document the final operating configuration. Update the persistent memory file with the deployed revision, remaining follow-ups, and links to the permanent maintenance documentation.
 
 **Deliverables:** Complete website development/operations guide, demonstrated author workflow, initial production review, and an owned follow-up backlog.
@@ -2052,6 +2054,8 @@ Ordered tasks:
 **Completion gate:** Another contributor can update a page without editing generated output or discovering undocumented setup. Required launch work is finished, operational ownership is clear, and remaining enhancements are explicitly tracked.
 
 **Timing note:** Checks requiring future traffic or a later observation period remain scheduled follow-up work. Do not mark future observations as completed during the launch session.
+
+**P12 implementation checkpoint:** Contributor documentation, routine workflows, clean-checkout exercise, operational ownership, prioritized backlog and dated future reviews are complete. The initial production review found readiness-loop and WebKit prefetch issues; fixes pass local checks and are being qualified through the protected publication workflow. P12.05/.08 remain open until publication/live verification and the outstanding P11.02 registrar confirmation are resolved. See [the maintenance handoff](p12-handoff.md); future observations and deferred API/manual-accessibility work are not claimed complete.
 
 ### 19.21 Phase completion record template
 

--- a/website/planning/maintenance.md
+++ b/website/planning/maintenance.md
@@ -1,0 +1,117 @@
+# Website maintenance, ownership and follow-up
+
+The production site is **https://ochatlabs.com**. Ochat remains the product and
+repository name. Use [contributor workflows](../CONTRIBUTING.md) for source edits,
+the [release runbook](release-runbook.md) for deployment/recovery, and
+[the launch record](p11-launch.md) for the first verified production baseline.
+
+## Operational ownership
+
+The accountable maintainer is **Dakota Murphy**, owner of
+`dakotamurphyucf/ochat`. A contributor may prepare a change; the maintainer owns
+its review, release policy and incident response. No backup account owner or
+second maintainer has been designated.
+
+| Responsibility | Owner and location | Maintenance action |
+| --- | --- | --- |
+| Domain registration and renewal | Dakota's GoDaddy account, `ochatlabs.com` | Keep billing/contact details current; purchase was $31 for two years, renewal quote $45 with period unspecified. Confirm the actual renewal date/term in the account; do not infer an annual price. |
+| Registrar contact verification | Dakota, GoDaddy contact email | Confirm completed verification or that no verification remains pending; no independent email/account audit is claimed. |
+| DNS, certificates and hosting | Dakota's Cloudflare account; zone and Worker IDs in the launch record | Preserve the Worker-managed apex/www records and Always Use HTTPS. Keep unrelated email/verification records intact. |
+| Repository and branch policies | Dakota, GitHub repository settings | Require `release-gate` from GitHub Actions, strict up-to-date checks and administrator enforcement; use PRs. |
+| Publication | The repository's Website workflow | `main` only, after full qualification, exact same-run retained artifact, serialized publication. Cloudflare Git builds and alternate automatic publishers stay disabled. |
+| Deployment credential | Dakota, GitHub Actions repository secret `CLOUDFLARE_API_TOKEN` | Rotate via Cloudflare and replace directly in GitHub; review account Workers and ochatlabs.com zone permissions. Never put token values in notes, commits or logs. |
+| Account recovery | Dakota, each provider's account/recovery settings | Maintain recovery email, MFA/recovery methods and recovery codes in private storage. This document assigns responsibility; it does not claim those settings have been inspected. |
+| Incident recovery and retained releases | Dakota, successful run artifacts and private archive storage | Preserve artifact, approval/evidence, revision and both Worker version IDs. Download before GitHub's 90-day retention expires; follow the runbook for a revert PR or emergency rollback. |
+
+The first public artifact is retained locally in
+`scratch/ochat-website-evidence/p11/qualified-production-b859aef7.tar.gz` with a
+SHA256 file. Scratch is ignored and machine-local; it is not a shared backup.
+The maintainer should keep a copy in their existing private backup storage.
+Do not commit release archives, credentials, account-recovery data or personal
+dashboard screenshots to make them shareable.
+
+## After a routine release
+
+1. Open the actual main run and confirm both `release-gate` and
+   `deploy-production` succeeded. A passing validation gate alone does not mean
+   the live release succeeded.
+2. Review `production-deployment-evidence`: the artifact SHA/revision must match
+   the run, and the hosted report must pass. Check the before/after versions of
+   both Workers; their updates are sequential, not atomic.
+3. Visit the homepage, Start here sequence, a nested reference, search result,
+   inline example, explicit download and missing route. Confirm `www` and HTTP
+   reach the HTTPS apex without losing a nested path or query.
+4. Record concrete failures and their scope. Keep failed-attempt evidence before
+   retrying. If only publication failed and the qualified revision is still
+   current main, retry the failed job after fixing the actual external cause;
+   do not rebuild or relabel an old preview as production.
+
+Cloudflare deployment events and the redirect Worker's sampled logs/traces are
+available to the owner in Workers & Pages. The static apex does not execute
+Worker code, so absence of invocation errors is not proof of healthy static
+assets. Use hosted byte/route checks and browser observations for that coverage.
+Sampling can miss errors; this launch-session review is not an uptime history
+or a field Core Web Vitals report.
+
+## Review calendar
+
+These are maintainer-owned review dates, **not installed calendar reminders or
+completed observations**. Record actual completion, findings and next due date
+here or in a linked repository issue when performed. No notifications have
+been sent to anyone.
+
+| Review | First due / cadence | Owner | Evidence to record |
+| --- | --- | --- | --- |
+| Initial operational follow-up | 2026-09-15, then after a failed deployment or reported outage | Dakota | Deployment status, representative routes/downloads, redirect errors, certificate validity and any account notices |
+| Content and example freshness | 2026-10-08, monthly and whenever related runtime contracts change | Dakota / author of the runtime change | Changed source contracts, stale verification labels, offline semantic results, corrected tutorial prerequisites |
+| External links and first-agent path | 2026-10-08, monthly | Dakota | Public provider/repository/install links, redirects, access changes and dated fixes; current build checks cover local links, not every external destination |
+| Framework and dependency review | 2026-10-08, monthly; earlier for relevant security advisories | Dakota | Official release notes, compatibility/lockfile changes, full qualification and cold/warm results for cache changes |
+| Usability, search and performance | 2026-10-08 or when useful reader feedback/traffic exists | Dakota | Real navigation difficulties, failed queries collected through approved means, device observations, lab budgets and field measurements only if available |
+| Release archive retention | By 2026-11-08 for the launch baseline; repeat before each archive's 90-day expiry | Dakota | Private backup location recorded privately, checksum verification and both version IDs |
+| Domain/account recovery | 2026-10-08, quarterly and before the actual GoDaddy renewal date | Dakota | Account access/contact/billing review; no secrets in repository evidence |
+
+Manual accessibility review remains explicitly deferred from launch. Its later
+timing is part of the usability review, using the existing
+[worksheet](manual-accessibility-review.md), rather than a claimed launch audit.
+
+## Prioritized backlog
+
+Priorities describe follow-up order, not new launch blockers. Work requiring
+provider calls, new analytics, paid infrastructure or external account changes
+must retain the relevant user-authorized scope.
+
+| Priority / ID | Work and rationale | Owner / acceptance |
+| --- | --- | --- |
+| P1 / CI-17 | Add normal Ochat and `@agent-e2e-pr` tests to the gate; website/docs tests do not establish full framework correctness. | Dakota; detailed task 17 in local `scratch/todo.md`, clean Linux qualification and failure enforcement |
+| P1 / CI-19 | Reduce workflow time: independent jobs in parallel, reproducible dependency caching, then measured browser sharding. | Dakota; task 19, cold/warm timing evidence, unchanged test coverage and exact-artifact qualification |
+| P1 / CI-18 | Select checks and deployments by real changed inputs; avoid unnecessary work while preserving required-gate behavior. | Dakota; task 18, conservative unknown-path handling and failed/skipped-job regression cases |
+| P1 / WEBKIT-01 | Monitor the P12 mitigation for intermittent prefetch access-control reports during rapid WebKit navigation. P12 reproduced the error and disables optional Starlight/Astro prefetching; native navigation and search remain enabled. | Dakota; preserve the P11/P12 reports and the three-engine regression; require measured benefit and clean browser behavior before re-enabling prefetch |
+| P1 / DEPS-01 | Rename the example prose `requirements.txt` under `docs-src/examples/applications/change-review/reference/` and update all canonical/catalog/capture references. GitHub's separate dependency graph workflow interprets it as pip requirements. | Dakota; dependency analysis succeeds and actual example/source parity remains checked; do not disable dependency scanning or overwrite the showcase |
+| P2 / API-01 | Reopen hosted odoc only after repairing references, defining API scope, and checking mounted assets/search/licenses. | Dakota; complete P09.02–P09.06 and the P09 review's inclusion conditions; preserve prose-only builds |
+| P2 / A11Y-01 | Perform the user-deferred screen-reader, native zoom, mobile keyboard and physical-device review. | Dakota / selected reviewer; dated worksheet, concrete fixes and retests, no blanket conformance claim |
+| P2 / SEARCH-01 | Expand the 21-query benchmark using actual reader needs; revisit compatibility ranking and long-tail/exact-identifier searches. Source-reader text and deferred API pages are intentionally excluded. | Dakota; record failing examples before tuning and preserve worker failure/retry and current-before-compatibility checks |
+| P2 / MEDIA-01 | Review existing workflow visuals and recorded/illustrative distinctions after feedback; consider a captioned short demonstration only if it improves comprehension. | Dakota; source provenance, captions/transcript/alternatives, self-hosting/license review and performance budgets |
+| P2 / DOCS-01 | Review the ten deferred canonical pages listed below against current interfaces before publishing. | Relevant code author, Dakota accountable; corrected prose, compiled/offline examples, explicit manifest promotion |
+
+Deferred-page inventory remains machine-owned by `config/docs-manifest.json`;
+the build regenerates its reasons in `.generated/migration-report.md`:
+
+- `chatml-host-session-controller-contract.md` and
+  `chatml-safe-point-and-effective-history.md`: reconcile steering/history
+  semantics and the finalized-output UTF-8 claim.
+- `examples/prompt-patterns.md`: classify mixed current/deprecated examples and
+  verify dependency closures.
+- `guide/general-agent-workflow.md`: supply missing companion files and review
+  external-account prerequisites and capability scope.
+- `lib/chat_tui/highlight_grammars.doc.md`, `highlight_registry.doc.md`,
+  `highlight_theme.doc.md` and `highlight_tm_engine.doc.md`: reconcile grammar
+  loading/theme interfaces, obsolete `default_dark` examples and malformed prose.
+- `lib/chat_tui/model.doc.md`: rewrite stale model/history/constructor examples
+  against the identity-bearing current model.
+- `lib/meta_prompting.doc.md`: reconcile old API/CLI examples with current
+  strategy context.
+
+Paths in that list are relative to `docs-src/`; grouped TUI filenames share
+`docs-src/lib/chat_tui/`. The 175 repository-only pages are not an implied
+commitment to publish every file. Promote material when it helps a defined
+reader task and passes review.

--- a/website/planning/p11-launch.md
+++ b/website/planning/p11-launch.md
@@ -1,9 +1,20 @@
 # P11 production launch
 
-Implementation target: **https://ochatlabs.com**, with www redirecting to the
-HTTPS apex. Production deployment is pending qualification and the first main
-publish. This record does not claim that an unperformed live check passed.
-The deployment history and immutable per-run evidence are available from the
+**Public launch verified:** https://ochatlabs.com, with www redirecting to the
+HTTPS apex. PR #21 merged normally at revision
+`b859aef70312a0f2553998a024f3c98561906106`.
+[Main run 34182707554](https://github.com/dakotamurphyucf/ochat/actions/runs/34182707554)
+passed all release checks; deployment attempt 2 published and verified the site
+on 2026-09-08 UTC (2026-09-07 CDT). GitHub's repository Website field and README
+now point to the owned domain. Milestone D's public visitor path is verified.
+
+The first deployment uploaded the static Worker but Cloudflare rejected the
+custom-domain attachment with error 100117. The user removed the conflicting
+apex A records (`13.248.243.5`, `76.223.105.230`) and www CNAME, preserving other
+DNS records. Only the failed deployment job was rerun; it reused the original
+passing checks and retained artifact without rebuilding.
+
+The immutable per-run evidence is available from the
 [Website workflow](https://github.com/dakotamurphyucf/ochat/actions/workflows/website.yml)
 and [production environment](https://github.com/dakotamurphyucf/ochat/deployments?environment=production).
 
@@ -68,6 +79,33 @@ cover onboarding, search, inline source reading and downloads. Final version IDs
 artifact hashes and results belong in the per-run reports and the persistent
 local record at `scratch/ochat-website-evidence/p11/closeout.json`.
 
-The GitHub repository Website field is updated after live verification; README
-entry points are included in this change. The full Ochat normal/E2E gate remains
-separate todo item 17, not a prerequisite added silently to P11.
+## Verified production release
+
+- Artifact SHA256: `304b0057bdecf2153d2099ed216124c69301ec2ce3866a3c61203270450b5182`.
+- Main Worker version: `2fe02ab9-1cc4-41ea-b0d9-d4bd94b23d19`; deployment `e28cb083-aca9-473a-b035-d07a4a1ee945`.
+- www Worker version: `1adc035f-ce24-4290-90bf-c14d024a730d`; deployment `e6b52ccd-f9ea-48d0-8c12-9d46331734d5`.
+- Both CI environments: 71 unit tests and zero Astro diagnostics; 256 browser passes and two existing clipboard skips each. The semantic gate passed 308 pages/38 methods; both search and performance gates passed.
+- Live hosting: 3,601 assertions passed for retained bytes, indexing, caching, MIME types, real 404s and HTTP/www canonical redirects. Initial certificate readiness failures were recorded before successful verification. Both public hostnames have trusted HTTPS certificates.
+- Live browsers: 21 checks passed across Chromium, Firefox and WebKit, covering onboarding order, search, mobile overflow, committed source links, inline ChatMD without JavaScript, explicit downloads and 404s.
+- GitHub: 18 post-merge policy checks passed. Website field, README links, reciprocal homepage repository link and representative exact-revision source destinations verified.
+
+The first live browser smoke run reported an intermittent WebKit prefetch
+access-control error during rapid navigation. Inspection found Astro already
+catches prefetch failures. An instrumented WebKit run and a full uninstrumented
+three-browser rerun passed against the unchanged artifact. Keep the initial
+report for P12 monitoring; no application or upstream fix is claimed.
+
+The first partial upload is not a previously live, verified production release.
+The qualified artifact above is the first public recovery baseline; retain its
+archive and version IDs beyond GitHub's 90-day artifact retention if needed.
+
+Registrar contact-email verification and the renewal quote's period remain
+owner-managed administrative follow-ups; neither is claimed independently
+verified. Domain connection, certificates and public website operation are
+verified. P11.02's contact-email confirmation remains open in the task checklist.
+The API-hosting and manual-accessibility deferrals are unchanged.
+
+Follow-up tasks in `scratch/todo.md`: 17 adds framework normal/E2E coverage,
+18 selects checks/deployments by changed inputs, and 19 improves workflow speed.
+These changes were not implemented as part of launch. The public site currently
+uses the full gate and automatic deployment on passing main runs.

--- a/website/planning/p12-handoff.md
+++ b/website/planning/p12-handoff.md
@@ -1,0 +1,90 @@
+# P12 maintenance handoff
+
+The contributor and operations handoff is implemented. Formal phase closeout
+still records the outstanding P11 registrar contact-email confirmation, rather
+than claiming an account detail that was not checked. Future reviews are assigned
+dates and owners, not marked as already performed.
+
+## Delivered documentation
+
+- [Contributor workflows](../CONTRIBUTING.md): clean setup, source ownership,
+  add/remove/move a page, example/capture maintenance, relevant checks,
+  dependency upgrades and the optional API regeneration boundary.
+- [Maintenance](maintenance.md): Dakota's operational/account responsibilities,
+  recovery/archive ownership, dated review calendar, and prioritized backlog
+  including all ten deferred canonical documents and tasks 17–19.
+- [Release runbook](release-runbook.md): current production publisher,
+  failed-job-only retry, readiness semantics and recovery procedure.
+- [Launch record](p11-launch.md): the first verified production artifact,
+  domain-conflict resolution, public links, versions and limits of the evidence.
+- Website README: removed stale statements that CI/publication/P11 were pending;
+  links now lead to the permanent contributor and maintenance documents.
+
+## Demonstrated contributor workflow
+
+A fresh public Git clone at launch revision
+`b859aef70312a0f2553998a024f3c98561906106` installed the locked dependencies
+with Node 22.22.1. No existing `node_modules`, generated website snapshot or
+OCaml switch was copied into that checkout.
+
+The exercise served the original first-agent tutorial, edited a prose sentence
+in `docs-src/agent-server/tutorials/local-tui.md`, observed watcher regeneration,
+and checked the new text in the dev response. The source-edit link resolved to
+that exact file on main; the immutable source link retained the public base
+revision. Both `npm run check` and `npm run build` passed with the edit, and the
+static output contained it. The temporary source change was restored; the clone
+ended with a clean Git status and its owned server was stopped. Eight exercise
+assertions passed. This demonstrates a local contributor workflow, not a new
+production artifact or a live model run.
+
+Evidence: local `scratch/ochat-website-evidence/p12/contributor-report.json`,
+install/check/build/dev logs and edited-preview HTML. The dev server selected
+port 4324 because earlier ports were occupied; the existing user's servers
+were preserved. An initial install using the ambient Node version was repeated
+with the pinned Node explicitly selected; both logs are retained.
+
+## Initial production review and fixes
+
+The deployed launch artifact passed a fresh 3,601-assertion hosted review,
+including principal/nested routes, search assets, downloads, indexing headers,
+real 404s, conditional caching and HTTP/www canonical redirects. The original
+publication failure was a resolved DNS conflict. Initial and failed-attempt
+evidence remains available; no long-term uptime or traffic claim is made.
+
+Two concrete issues were addressed:
+
+1. **Readiness retries:** the old probe assigned readiness after the apex fetch
+   before awaiting www. If www then threw, the next loop condition could stop
+   retries early. The new helper only succeeds after both checks finish in the
+   same observation, records failed probes and exhausts a bounded retry count.
+   Regression tests cover delayed www certificates, permanent failure, stale
+   apex bytes and wrong redirects. The full hosted review passes with the new
+   helper; later hosted checks had already protected the original release.
+2. **WebKit speculative requests:** the post-launch browser review reproduced
+   the earlier prefetch access-control report. Astro catches fetch rejection,
+   but WebKit still reported an error during rapid navigation. Optional
+   Starlight/Astro prefetching is disabled explicitly. A browser regression
+   verifies hover/focus does not issue speculative document requests and that
+   installation → troubleshooting → first-agent navigation remains error-free
+   in Chromium, Firefox and WebKit. Search remains a separate on-demand worker.
+   This is a site-level mitigation, not a claimed upstream browser fix.
+
+Local validation passes 74 unit tests, zero Astro diagnostics, the fixed preview
+build, and all three targeted browser regressions. The full protected CI matrices
+and the post-merge hosted report qualify the final publication independently;
+their immutable reports are available from the
+[Website workflow](https://github.com/dakotamurphyucf/ochat/actions/workflows/website.yml).
+Local reports live in `scratch/ochat-website-evidence/p12/`.
+
+## Scope retained
+
+P09 odoc hosting and P10.03 manual accessibility remain explicitly deferred.
+Tasks 17–19 are backlog items, not implemented gate changes. GoDaddy contact-email
+verification and the renewal quote's period remain owner-managed/unconfirmed.
+The review calendar schedules future observations without installing reminders
+or sending messages. The maintainer owns their follow-through.
+
+The production website is the qualified Cloudflare artifact, not local generated
+output. Both Workers and the exact artifact/commit remain linked through per-run
+deployment reports; scratch memory records the current deployed revision and
+open work. Do not make a new production claim from local checks alone.

--- a/website/planning/release-runbook.md
+++ b/website/planning/release-runbook.md
@@ -6,6 +6,10 @@ or an automated accessibility scan does not establish hosted behavior or manual
 accessibility conformance. See [the P10 review](p10-completion-review.md) for the
 current evidence and outstanding gates.
 
+Production is now live; see [the P11 launch record](p11-launch.md) for its
+verified baseline. [Contributor workflows](../CONTRIBUTING.md) and
+[maintenance ownership](maintenance.md) cover routine work and review dates.
+
 ## One publication owner
 
 The Website workflow is the sole production publisher for `https://ochatlabs.com`.
@@ -153,6 +157,11 @@ recorded separately. Treat an upload success as the start of qualification:
 first-deployment propagation can expose transient asset errors, and the public
 checks must pass before the environment is declared ready.
 
+The production readiness loop requires matching apex bytes and the exact www
+redirect in one completed probe. A failed www certificate/request must remain
+not ready even when the apex has already responded successfully. Every failed
+probe is recorded, retries are bounded, and the full hosted checks still follow.
+
 Use an explicitly selected account/project and a preview artifact built for its
 preview origin. Record the Worker name, version/deployment IDs, origin, source
 revision, and exact uploaded artifact hash. Verify over public HTTPS:
@@ -239,6 +248,29 @@ account before upload. Sources reviewed on 2026-09-07:
 GitHub owns builds in this design; Cloudflare Workers Builds is not configured.
 
 ## Production recovery
+
+### Retry an externally blocked deployment
+
+If the release gate passed but only publication failed, first resolve the
+specific cause and confirm the run's revision is still current main. For the
+launch, Cloudflare error 100117 identified conflicting apex A records and a www
+CNAME; the owner removed only those records, preserving unrelated DNS entries.
+Do not remove unrelated email or verification records or blindly retry a failed
+DNS attachment.
+
+```sh
+gh run view RUN_ID --log-failed
+gh run rerun RUN_ID --failed
+```
+
+Replace `RUN_ID` with the affected main run. The launch successfully used this
+path: only `deploy-production` reran, downloaded the original qualified artifact
+and evidence, and performed the live checks. Keep reports/logs from the failed
+attempt separately before downloading the retry's evidence. Never reuse a
+passing artifact for a different source revision. A superseded revision is
+intentionally rejected; qualify current main through the normal workflow.
+
+### Restore a known-good release
 
 Prefer a normal revert PR: revert the faulty website change, let the full gate
 qualify the reverted code at its new main revision, and publish through the same

--- a/website/scripts/production-readiness.mjs
+++ b/website/scripts/production-readiness.mjs
@@ -1,0 +1,40 @@
+import { createHash } from 'node:crypto';
+import { productionOrigin } from '../config/production.mjs';
+
+// A successful apex response alone must not end readiness retries: the www
+// certificate and route must also be ready in the same completed observation.
+export async function waitForProduction({
+  get,
+  homepageSha256,
+  attempts,
+  maxAttempts = 12,
+  pause = () => new Promise((resolve) => setTimeout(resolve, 5000)),
+}) {
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      const response = await get('/');
+      const matchingBytes =
+        response.status === 200 &&
+        createHash('sha256')
+          .update(Buffer.from(await response.arrayBuffer()))
+          .digest('hex') === homepageSha256;
+      const alternate = await get('https://www.ochatlabs.com/');
+      const ready =
+        matchingBytes &&
+        alternate.status === 308 &&
+        alternate.headers.get('location') === productionOrigin + '/';
+      attempts.push({
+        attempt,
+        status: response.status,
+        matchingBytes,
+        alternateStatus: alternate.status,
+        ready,
+      });
+      if (ready) return true;
+    } catch (error) {
+      attempts.push({ attempt, error: error.message });
+    }
+    if (attempt < maxAttempts) await pause();
+  }
+  return false;
+}

--- a/website/scripts/rehearse-hosted.mjs
+++ b/website/scripts/rehearse-hosted.mjs
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { createHash } from 'node:crypto';
 import { verifyArtifact } from './release-artifact.mjs';
 import { productionOrigin } from '../config/production.mjs';
+import { waitForProduction } from './production-readiness.mjs';
 
 const [directory, output] = process.argv.slice(2);
 if (!directory || !output)
@@ -78,30 +79,11 @@ try {
     // Preserve each observation; never silently retry a completed verification.
     report.readiness = [];
     const homepage = artifact.files.find((file) => file.path === 'index.html');
-    let ready = false;
-    for (let attempt = 0; attempt < 12 && !ready; attempt++) {
-      try {
-        const response = await get('/');
-        ready =
-          response.status === 200 &&
-          hash(Buffer.from(await response.arrayBuffer())) === homepage.sha256;
-        const alternate = await get('https://www.ochatlabs.com/');
-        ready =
-          ready &&
-          alternate.status === 308 &&
-          alternate.headers.get('location') === productionOrigin + '/';
-        report.readiness.push({
-          attempt: attempt + 1,
-          status: response.status,
-          matchingBytes: ready,
-          alternateStatus: alternate.status,
-        });
-      } catch (error) {
-        report.readiness.push({ attempt: attempt + 1, error: error.message });
-      }
-      if (!ready && attempt < 11)
-        await new Promise((resolve) => setTimeout(resolve, 5000));
-    }
+    const ready = await waitForProduction({
+      get,
+      homepageSha256: homepage.sha256,
+      attempts: report.readiness,
+    });
     check(ready, 'Production hostname serves the current artifact over HTTPS');
   }
   async function checkFile(file) {

--- a/website/tests/browser/reading.spec.ts
+++ b/website/tests/browser/reading.spec.ts
@@ -2,6 +2,37 @@ import { test, expect } from '@playwright/test';
 
 const routes = ['/', '/docs/start/first-agent/', '/docs/reference/chatml/'];
 
+test('onboarding links navigate without speculative document requests', async ({
+  page,
+}) => {
+  const speculative: string[] = [];
+  const errors: string[] = [];
+  page.on('pageerror', (error) => errors.push(error.message));
+  page.on('request', (request) => {
+    if (
+      new URL(request.url()).pathname.startsWith('/docs/') &&
+      ['fetch', 'xhr'].includes(request.resourceType())
+    )
+      speculative.push(request.url());
+  });
+  await page.goto('/docs/start/installation/');
+  const next = page.getByRole('link', { name: /Next.*Build troubleshooting/ });
+  await next.hover();
+  await next.focus();
+  // Allow the former hover/focus prefetch delay to expire before navigating.
+  await page.waitForTimeout(300);
+  expect(speculative).toEqual([]);
+  await next.click();
+  await page
+    .getByRole('link', { name: /Next.*Run your first local agent/ })
+    .click();
+  await expect(page.getByRole('heading', { level: 1 })).toHaveText(
+    'Run your first local agent',
+  );
+  expect(speculative).toEqual([]);
+  expect(errors).toEqual([]);
+});
+
 test('skip links move keyboard navigation into the main content', async ({
   page,
   browserName,

--- a/website/tests/production-readiness.test.mjs
+++ b/website/tests/production-readiness.test.mjs
@@ -1,0 +1,75 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { waitForProduction } from '../scripts/production-readiness.mjs';
+
+const homepageSha256 = createHash('sha256').update('current').digest('hex');
+const redirect = () => Response.redirect('https://ochatlabs.com/', 308);
+
+test('readiness retries www certificate failures even when the apex already matches', async () => {
+  const attempts = [];
+  let alternateCalls = 0;
+  let pauses = 0;
+  const ready = await waitForProduction({
+    homepageSha256,
+    attempts,
+    pause: async () => pauses++,
+    get: async (route) => {
+      if (route === '/') return new Response('current');
+      if (++alternateCalls < 3) throw new Error('certificate not ready');
+      return redirect();
+    },
+  });
+  assert.equal(ready, true);
+  assert.equal(alternateCalls, 3);
+  assert.equal(pauses, 2);
+  assert.equal(attempts.length, 3);
+  assert.equal(attempts[0].error, 'certificate not ready');
+  assert.equal(attempts[1].error, 'certificate not ready');
+  assert.equal(attempts[2].ready, true);
+});
+
+test('readiness exhausts its bound when www never becomes reachable', async () => {
+  const attempts = [];
+  let pauses = 0;
+  assert.equal(
+    await waitForProduction({
+      homepageSha256,
+      attempts,
+      maxAttempts: 3,
+      pause: async () => pauses++,
+      get: async (route) => {
+        if (route === '/') return new Response('current');
+        throw new Error('www unavailable');
+      },
+    }),
+    false,
+  );
+  assert.equal(attempts.length, 3);
+  assert.equal(pauses, 2);
+  assert.ok(attempts.every((attempt) => attempt.error === 'www unavailable'));
+});
+
+test('readiness rejects stale apex bytes and incorrect alternate redirects', async () => {
+  for (const scenario of ['stale', 'wrong-host', 'wrong-status']) {
+    const attempts = [];
+    assert.equal(
+      await waitForProduction({
+        homepageSha256,
+        attempts,
+        maxAttempts: 1,
+        get: async (route) => {
+          if (route === '/')
+            return new Response(scenario === 'stale' ? 'old' : 'current');
+          if (scenario === 'wrong-host')
+            return Response.redirect('https://other.example/', 308);
+          if (scenario === 'wrong-status') return new Response('no redirect');
+          return redirect();
+        },
+      }),
+      false,
+      scenario,
+    );
+    assert.equal(attempts[0].ready, false);
+  }
+});


### PR DESCRIPTION
The website now has a contributor workflow and an operational handoff covering source ownership, routine edits, recovery, scheduled reviews and the deferred-work backlog. Update the launch records and remove README statements that still described production as pending.

Fix two issues found during the post-launch review: readiness retries now continue when www is unavailable even if the apex already matches, and optional Astro/Starlight prefetching is disabled after recurring WebKit errors during rapid navigation. Native navigation and on-demand search remain enabled. Add focused readiness and three-engine browser regressions.

Validation: 74 unit tests and zero Astro diagnostics; fixed preview build; all three targeted browser regressions; a fresh public clone with a locked Node22.22.1 install, source edit/watcher preview, correct source-edit links, checks and static build; 3,601 live hosted assertions using the corrected readiness helper. Full [PR run34185145288](https://github.com/dakotamurphyucf/ochat/actions/runs/34185145288) passed the semantic gate, both website matrices (259 browser passes and two existing skips each), all74unit checks, search/performance and release-gate. Downloaded reports reconcile to the exact commit and production artifact; retained artifact verification passes. P11 registrar contact-email confirmation remains owner-managed/unconfirmed; future review dates, API hosting and manual accessibility are not claimed completed. Tasks17–19 remain backlog-only.
