### PR TITLE
Document CI qualification and verify maintainer-only check selection

### DIFF
--- a/website/planning/ci-qualification.md
+++ b/website/planning/ci-qualification.md
@@ -12,12 +12,19 @@ previously qualified launch closeout from PR #23, which GitHub marked merged.
 | --- | --- | --- | --- |
 | [34186360736](https://github.com/dakotamurphyucf/ochat/actions/runs/34186360736) | Previous workflow baseline, without framework tiers | 1,217 s (20m 17s) | 1,856 s |
 | [34191242088](https://github.com/dakotamurphyucf/ochat/actions/runs/34191242088) | Both framework dependency caches hit; semantics rebuilt for a different CPU | 748 s (12m 28s) | 2,269 s |
+| [34192166776](https://github.com/dakotamurphyucf/ochat/actions/runs/34192166776) | First main run; all three project dependency caches missed | 968 s (16m 08s) | 3,515 s |
 
 The passing PR gate was approximately 39% faster with the added framework
 coverage. Summed validation runner time increased approximately 22%; it is a
 measure of elapsed job time, not a billing estimate. The new run was a mixed-cache
 run, not a claim of a fully warm workflow. GitHub queue and runner variation limit
 what can be inferred from individual runs.
+
+The first main run was approximately 20% faster than the old gate despite fresh
+project dependency builds for all three OCaml jobs. Its greater runner usage
+reflects three fresh installations and the added framework coverage. The PR's
+mixed cache reuse reduced summed runner time by about 35% compared with that
+fresh main run. These are observed samples, not guaranteed timing targets.
 
 Both website environments passed 75 unit tests, Astro validation, build checks,
 7 performance routes, 21 search benchmark queries, and 259 browser tests each.
@@ -76,14 +83,27 @@ Main run [34192166776](https://github.com/dakotamurphyucf/ochat/actions/runs/341
 selected framework, semantics, website and deployment for the actual merge.
 Its deployment lookup found successful production revision
 `077b00f905cb4ac61608294b35acd89a7a42a679`, with no fallback, and included the
-unshipped input diff. Full main qualification and publication are in progress.
+unshipped input diff. All selected jobs, the gate, publication and hosted
+verification passed. Both framework dependency caches missed and their forced
+test commands passed (189.075 s normal; 68.596 s E2E). All qualification artifacts
+were reconciled to the merge revision; the production artifact hash is
+`5c527f54c2ce2bb9063071f97678adcee443dd8715e317a5398932d78e2cc269`.
+All 3,594 hosted checks passed for the served bytes, routing, HTTPS, headers and
+conditional caching at `https://ochatlabs.com`.
+Post-merge verification passed 21 checks, including strict required-gate
+enforcement for administrators, required PRs, disabled force pushes/deletion,
+the exact main-only production environment, and the deployed merge revision.
 The maintainer-only [PR #25](https://github.com/dakotamurphyucf/ochat/pull/25)
 changes this qualification record. Its first
 [run 34192361126](https://github.com/dakotamurphyucf/ochat/actions/runs/34192361126)
 completed the required gate in 28 seconds (22 summed runner-seconds). Detection
 selected no heavy jobs, without fallback; `changes` and `release-gate` passed,
-and framework, semantics, website and publication explicitly skipped. The main
-push probe follows successful publication of the framework changes.
+and framework, semantics, website and publication explicitly skipped. The PR is
+merged only after the framework changes are successfully published, so the
+subsequent main push can use that release as its deployment baseline. The
+retained `ci-selection` report and job summary record the main decision; the
+local closeout verification checks that publication skips and production retains
+the qualified `0595f08c` revision.
 
 Manual `validate`, `cold`, and main-only `redeploy` modes and the weekly cold audit
 are configured. Policy tests cover their selection; the actual publisher entry

--- a/website/planning/ci-qualification.md
+++ b/website/planning/ci-qualification.md
@@ -1,19 +1,102 @@
 # CI qualification record
 
-Tasks 17–19 are undergoing Linux qualification in
-[PR #24](https://github.com/dakotamurphyucf/ochat/pull/24).
-Final successful gate timings and protected-main publication results will be
-recorded here after qualification; pending or failed runs are not speed results.
+The framework, selection and caching changes were merged through protected
+[PR #24](https://github.com/dakotamurphyucf/ochat/pull/24), after full Linux
+qualification of source `0ec4b4997bdcaee7cd6aefa77e8b4a012e850b2d`.
+The merge is `0595f08ced3467641d697d1b1d2a36ed3b201dcc`. It also includes the
+previously qualified launch closeout from PR #23, which GitHub marked merged.
 
-The baseline successful gate took 1,217 seconds with 1,856 summed validation
-runner-seconds in [run 34186360736](https://github.com/dakotamurphyucf/ochat/actions/runs/34186360736).
-It did not include the new normal/E2E framework tiers.
+## Successful qualification and timing
 
-Initial Linux failures blocked the required gate and publication. Corrected
-normal tests passed in run 34189116967; the complete PR-safe E2E tier passed in
-run 34190368673. Neither alone qualifies a release. See the
-[maintenance guide](ci-enforcement.md) for coverage, selection, cache operations,
-and the platform issues addressed during qualification.
+| Run | Cache condition | Time to required gate | Summed validation runner time |
+| --- | --- | --- | --- |
+| [34186360736](https://github.com/dakotamurphyucf/ochat/actions/runs/34186360736) | Previous workflow baseline, without framework tiers | 1,217 s (20m 17s) | 1,856 s |
+| [34191242088](https://github.com/dakotamurphyucf/ochat/actions/runs/34191242088) | Both framework dependency caches hit; semantics rebuilt for a different CPU | 748 s (12m 28s) | 2,269 s |
 
-Browser sharding has not been introduced. Its necessity will be assessed using
-successful cold/warm measurements while retaining every browser/environment.
+The passing PR gate was approximately 39% faster with the added framework
+coverage. Summed validation runner time increased approximately 22%; it is a
+measure of elapsed job time, not a billing estimate. The new run was a mixed-cache
+run, not a claim of a fully warm workflow. GitHub queue and runner variation limit
+what can be inferred from individual runs.
+
+Both website environments passed 75 unit tests, Astro validation, build checks,
+7 performance routes, 21 search benchmark queries, and 259 browser tests each.
+Two existing non-Chromium clipboard cases remained intentionally skipped in each
+environment. Chromium, Firefox and WebKit all participated. The production
+artifact, browser/search/performance reports, and same-revision semantic evidence
+were downloaded and reconciled; exact-artifact production verification passed.
+
+| Framework command | Fresh dependency/object builds, run 34190368673 | Verified dependency reuse, run 34191242088 |
+| --- | --- | --- |
+| `dune runtest --force` | 191.459 s, pass | 119.283 s, pass |
+| `dune build --force @agent-e2e-pr` | 68.642 s, pass | 15.353 s, pass |
+
+These command timings exclude toolchain setup. The earlier run's framework tiers
+passed, but its semantic link check failed, so it did not qualify a release.
+Forced aliases still executed the selected tests on cache hits. Dune caches only
+compiled objects; `_build` and prior test outcomes are not restored.
+
+The runner fingerprints actually included `icelake-server`, `znver3`, and
+`graniterapids` CPU targets. The final PR's semantic job correctly missed the
+cache for the third target, rebuilt locked dependencies, and passed. Both
+framework tiers restored the compatible `znver3` cache and passed. This validates
+both reuse and CPU-based invalidation on real hosted runners.
+
+## Failure enforcement and fixes
+
+The initial Linux expansion run
+[34188359989](https://github.com/dakotamurphyucf/ochat/actions/runs/34188359989)
+failed framework tests, failed the required gate, and skipped publication while
+website and semantic jobs passed. No protection bypass was used.
+
+Qualification exposed and addressed:
+
+- Nottui 0.5 introducing a second incompatible Notty implementation; constrain
+  Nottui below 0.5 and qualify the matching Linux lock.
+- BSD/GNU `wc` whitespace differences; assert the parsed byte count and status.
+- Linux resetting an oversized Unix socket request; accept only EOF or the typed
+  connection reset, retain response rejection and subsequent daemon-health checks.
+- `/bin` executable symlinks on Linux; use canonical executable paths in fixture
+  allow rules while preserving default denial and the intended commands.
+- Git background maintenance removing a lock while opam copies repository data;
+  disable automatic maintenance on the disposable CI runner.
+- Illegal-instruction failures after native dependency reuse; include the native
+  CPU target in both dependency and Dune cache keys.
+- A maintainer guide link entering Dune's documentation build tree; link from
+  `DEVELOPMENT.md` to the GitHub guide, preserving the intentional exclusion of
+  the website's separate toolchain from Dune.
+
+Superseded PR run 34190128251 was cancelled by the new concurrency policy. Its
+already completed failure evidence remains useful; its timing is not treated as
+a passing speed measurement.
+
+## Main deployment and selection verification
+
+Main run [34192166776](https://github.com/dakotamurphyucf/ochat/actions/runs/34192166776)
+selected framework, semantics, website and deployment for the actual merge.
+Its deployment lookup found successful production revision
+`077b00f905cb4ac61608294b35acd89a7a42a679`, with no fallback, and included the
+unshipped input diff. Full main qualification and publication are in progress.
+The final maintainer-only PR/main selection probe follows successful publication.
+
+Manual `validate`, `cold`, and main-only `redeploy` modes and the weekly cold audit
+are configured. Policy tests cover their selection; the actual publisher entry
+point rejects disallowed events, refs, repositories and modes before touching
+credentials or artifacts. This is not a claim that a future scheduled audit or a
+manual recovery has already executed.
+
+## Browser sharding decision
+
+Retain the two-worker suites in both environments for this change. Concurrency,
+qualified dependency reuse, and Dune object reuse have already reduced the gate
+by approximately eight minutes while adding framework coverage. Browser suites
+remain the longest warm-workflow component (about 9.3 minutes each). Sharding is
+a possible separate optimization, with additional runners and artifact/evidence
+coordination; it has not shipped here. Any future implementation must test the
+same artifact, retain all three engines and both environments, and require every
+shard result before publication.
+
+See [CI coverage and maintenance](ci-enforcement.md) for the selection policy,
+lock refresh, cache recovery, manual modes and retained evidence. Detailed local
+reports and resumable implementation notes remain under `scratch/` and are not
+published website assets or a shared backup.

--- a/website/planning/ci-qualification.md
+++ b/website/planning/ci-qualification.md
@@ -77,7 +77,13 @@ selected framework, semantics, website and deployment for the actual merge.
 Its deployment lookup found successful production revision
 `077b00f905cb4ac61608294b35acd89a7a42a679`, with no fallback, and included the
 unshipped input diff. Full main qualification and publication are in progress.
-The final maintainer-only PR/main selection probe follows successful publication.
+The maintainer-only [PR #25](https://github.com/dakotamurphyucf/ochat/pull/25)
+changes this qualification record. Its first
+[run 34192361126](https://github.com/dakotamurphyucf/ochat/actions/runs/34192361126)
+completed the required gate in 28 seconds (22 summed runner-seconds). Detection
+selected no heavy jobs, without fallback; `changes` and `release-gate` passed,
+and framework, semantics, website and publication explicitly skipped. The main
+push probe follows successful publication of the framework changes.
 
 Manual `validate`, `cold`, and main-only `redeploy` modes and the weekly cold audit
 are configured. Policy tests cover their selection; the actual publisher entry


### PR DESCRIPTION
Document the completed Linux CI qualification, native-cache compatibility fixes, failure enforcement, measured gate timings, and protected-main production deployment from PR #24.

Full PR qualification passed in 12m28s with mixed cache reuse; the fresh main run passed its gate in 16m08s and completed publication plus all 3,594 hosted checks. The prior gate baseline was 20m17s without the new framework tiers. The record includes runner-usage tradeoffs and the decision to retain the existing browser suites after measuring the simpler improvements.

Only the maintainer qualification record changes. Initial run 34192361126 passed the required gate in 28s with framework, semantic, website and publication jobs explicitly skipped; no fallback was used. The final head repeats that selection check. Main's successful publication at 0595f08c is now available as the deployment baseline; the following documentation-only main run will be checked for skipped publication.
