### PR TITLE
Split browser qualification into two shards per environment

### DIFF
--- a/.github/scripts/ci-policy.mjs
+++ b/.github/scripts/ci-policy.mjs
@@ -82,8 +82,17 @@ export function requireSelectedJobs(needs) {
   if (needs.changes?.result !== "success")
     throw new Error("Change detection did not succeed");
   const decisions = [];
-  for (const name of ["semantics", "framework", "website"]) {
-    const selected = needs.changes.outputs?.[name];
+  for (const name of [
+    "semantics",
+    "framework",
+    "website",
+    "browser",
+    "website-qualification",
+  ]) {
+    const selection = ["browser", "website-qualification"].includes(name)
+      ? "website"
+      : name;
+    const selected = needs.changes.outputs?.[selection];
     if (!["true", "false"].includes(selected))
       throw new Error(`Missing or invalid selection for ${name}`);
     const expected = selected === "true" ? "success" : "skipped";

--- a/.github/tests/ci-policy.test.mjs
+++ b/.github/tests/ci-policy.test.mjs
@@ -122,8 +122,10 @@ test("gate accepts only successful selected jobs and explicitly unnecessary skip
       needs.changes.outputs[names[index]] = String(selected);
       needs[names[index]] = { result: selected ? "success" : "skipped" };
     }
-    assert.equal(requireSelectedJobs(needs).length, 3);
-    for (const name of names)
+    for (const name of ["browser", "website-qualification"])
+      needs[name] = { result: needs.website.result };
+    assert.equal(requireSelectedJobs(needs).length, 5);
+    for (const name of [...names, "browser", "website-qualification"])
       for (const status of [
         "failure",
         "cancelled",

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -155,26 +155,24 @@ jobs:
       - run: npm ci
       - run: npm run check
       - run: npm run build
-      - run: npx playwright install --with-deps chromium firefox webkit
+      - run: npx playwright install --with-deps chromium
       - run: npm run measure:performance
       - run: npm run evaluate:search
-      - run: npm run test:browser -- --workers=2
-      - name: Retain tested production artifact
-        if: matrix.environment == 'production'
+      - name: Retain build and discover complete browser suite
         run: |
           mkdir -p .release
           npm run artifact -- retain .release/candidate
-          cp test-results/.last-run.json .release/candidate/browser-result.json
+          node scripts/browser-ci.mjs plan .release/candidate
       - name: Validate Cloudflare production packaging
         if: matrix.environment == 'production'
         run: |
           node node_modules/wrangler/bin/wrangler.js deploy --dry-run --config .release/candidate/wrangler.jsonc --env production
           node node_modules/wrangler/bin/wrangler.js deploy --dry-run --config .release/candidate/redirect/wrangler.jsonc
-      - name: Upload tested production artifact
-        if: matrix.environment == 'production'
+      - name: Upload prepared build for browser shards
         uses: actions/upload-artifact@v4
         with:
-          name: website-production-release
+          name: website-build-${{ matrix.environment }}
+          overwrite: true
           path: website/.release/candidate/
           include-hidden-files: true
           retention-days: 90
@@ -184,6 +182,7 @@ jobs:
         with:
           include-hidden-files: true
           name: website-evidence-${{ matrix.environment }}
+          overwrite: true
           path: |
             website/.generated/capacity-report.json
             website/.generated/applications-report.json
@@ -199,9 +198,111 @@ jobs:
             website/.generated/search-report.json
             website/.generated/search-report.md
             website/test-results/
+  browser:
+    needs: [changes, website]
+    if: needs.changes.outputs.website == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        environment: [preview, production]
+        shard: [1, 2]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    env:
+      SITE_ENV: ${{ matrix.environment }}
+      SITE_URL: ${{ matrix.environment == 'production' && 'https://ochatlabs.com' || 'http://localhost:4321' }}
+    defaults:
+      run:
+        working-directory: website
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: website/.nvmrc
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+      - run: npm ci
+      - uses: actions/download-artifact@v4
+        with:
+          name: website-build-${{ matrix.environment }}
+          path: website/.release/candidate
+      - run: npx playwright install --with-deps chromium firefox webkit
+      - name: Test prepared artifact on shard ${{ matrix.shard }}/2
+        run: node scripts/browser-ci.mjs run .release/candidate ${{ matrix.shard }}
+      - name: Retain shard report and failure traces
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: website-browser-${{ matrix.environment }}-${{ matrix.shard }}
+          path: website/.release/browser/
+          include-hidden-files: true
+          retention-days: 90
+          if-no-files-found: error
+          overwrite: true
+  website-qualification:
+    needs: [changes, website, browser]
+    # Merge failed shards for diagnosis too; qualification still fails closed.
+    if: "!cancelled() && needs.changes.outputs.website == 'true' && needs.website.result == 'success'"
+    strategy:
+      fail-fast: false
+      matrix:
+        environment: [preview, production]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    env:
+      SITE_ENV: ${{ matrix.environment }}
+    defaults:
+      run:
+        working-directory: website
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: website/.nvmrc
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+      - run: npm ci
+      - uses: actions/download-artifact@v4
+        with:
+          name: website-build-${{ matrix.environment }}
+          path: website/.release/candidate
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: website-browser-${{ matrix.environment }}-*
+          path: website/.release/shards
+      - name: Merge reports and require complete browser coverage
+        run: node scripts/browser-ci.mjs merge .release/candidate
+      - name: Upload qualified production artifact
+        if: matrix.environment == 'production' && needs.browser.result == 'success'
+        uses: actions/upload-artifact@v4
+        with:
+          name: website-production-release
+          path: website/.release/candidate/
+          include-hidden-files: true
+          retention-days: 90
+          if-no-files-found: error
+          overwrite: true
+      - name: Retain merged browser evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: website-browser-qualification-${{ matrix.environment }}
+          path: |
+            website/.release/browser/
+            website/.release/candidate/browser-result.json
+          include-hidden-files: true
+          retention-days: 90
+          if-no-files-found: error
+          overwrite: true
   release-gate:
     if: always()
-    needs: [changes, semantics, framework, website]
+    needs: [changes, semantics, framework, website, browser, website-qualification]
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ website/.generated/
 website/src/content/docs/
 website/test-results/
 website/playwright-report/
+website/blob-report/
 website/src/content/.docs-*/
 website/.generated-previous/
 website/.generated-stage-*/

--- a/website/planning/ci-enforcement.md
+++ b/website/planning/ci-enforcement.md
@@ -13,7 +13,9 @@ publisher. Strict branch protection, administrator enforcement, and the exact
 | `framework (normal)` | Run `opam exec -- dune runtest --force`. |
 | `framework (e2e)` | Run `opam exec -- dune build --force @agent-e2e-pr`: daemon smoke, Unix/stdio/HTTP transports, transport conformance, workspaces and multiple clients. |
 | `semantics` | Run the offline documentation checks and retain evidence for this exact revision. |
-| `website (preview)` and `website (production)` | Unit/Astro checks, build, performance, search, Chromium/Firefox/WebKit tests; production packaging and retained artifact checks. |
+| `website (preview)` and `website (production)` | Unit/Astro checks, one build per environment, performance, search, full browser-test discovery and retained build; production packaging checks. |
+| `browser (environment, shard)` | Two shards per environment, two workers each, zero retries; Chromium/Firefox/WebKit tests against that environment's downloaded build. |
+| `website-qualification (environment)` | Merge both shard reports, verify complete disjoint test coverage and exact artifact/revision/run identity; retain the qualified production artifact. |
 | `release-gate` | Always run; require successful detection and every selected job. Accept a skipped job only when detection explicitly marked it unnecessary. |
 | `deploy-production` | Publish a same-run qualified artifact on main when selected, then verify the hosted site. |
 
@@ -26,6 +28,37 @@ tiers run independently; a failure does not cancel evidence from the other tier.
 Load, soak, live-provider, and manual-terminal tiers remain separate. These jobs
 receive no model credentials and make no paid model requests. Website jobs start
 after detection, concurrently with the OCaml jobs.
+
+## Browser sharding and artifacts
+
+Each environment builds once and uploads `website-build-preview` or
+`website-build-production`. Each contains the retained manifest, exact `dist/`
+bytes, generated fixture reports and an unsharded Playwright discovery plan.
+The four browser jobs download their environment's build, verify its revision,
+lockfile and content hash, restore its bytes and fixtures without rebuilding,
+and verify the served copy again after execution. Existing platform-specific
+clipboard skips remain explicit; retries remain disabled.
+
+Every shard uploads a machine-readable report, a Playwright blob report and
+failure traces as `website-browser-ENVIRONMENT-INDEX`. The environment's
+qualification job merges the blob reports into HTML/JSON and requires both
+shard indices, all three engines, every planned test exactly once, successful
+execution, and matching revision, artifact hash and workflow run. Failed or
+cancelled browser jobs still block `release-gate`, even if another environment
+qualifies. Missing evidence fails qualification. Merged diagnostic reports are
+retained when available; setup failures may have no Playwright report.
+
+Only successful qualification can upload `website-production-release`.
+Production verification rechecks the full shard evidence, not just a summarized
+pass flag. All downloads are from the current run. Failed-job reruns can reuse
+successful shards from an earlier attempt of that same run when the artifact
+hash and revision match; rerun uploads replace their own named evidence.
+A previous run's browser summary cannot qualify a new release.
+
+The additional runners and artifact transfer have overhead. Compare time to the
+required gate, individual browser durations, total validation runner time and
+failures in the [qualification record](ci-qualification.md) before expanding
+beyond two shards. The two-worker limit avoids overloading each runner.
 
 ## Change selection and publication
 

--- a/website/planning/ci-qualification.md
+++ b/website/planning/ci-qualification.md
@@ -111,7 +111,7 @@ point rejects disallowed events, refs, repositories and modes before touching
 credentials or artifacts. This is not a claim that a future scheduled audit or a
 manual recovery has already executed.
 
-## Browser sharding decision
+## Original browser sharding decision (tasks 17–19)
 
 Retain the two-worker suites in both environments for this change. Concurrency,
 qualified dependency reuse, and Dune object reuse have already reduced the gate
@@ -126,3 +126,19 @@ See [CI coverage and maintenance](ci-enforcement.md) for the selection policy,
 lock refresh, cache recovery, manual modes and retained evidence. Detailed local
 reports and resumable implementation notes remain under `scratch/` and are not
 published website assets or a shared backup.
+
+
+## Two-shard follow-up
+
+The follow-up implements two shards per environment while preserving all three
+engines, two workers per shard, zero retries and the exact prepared artifact.
+Discovery and execution evidence must cover every planned test exactly once;
+all four browser jobs and both qualification jobs participate in the gate.
+Local policy tests exercise missing, duplicate, failed, cancelled, stale and
+partially executed evidence. A real Playwright fixture exercises discovery,
+two shard reporters, explicit skips and blob merging without launching browsers.
+
+Hosted qualification and measured timing results are pending. Compare against
+the prior mixed-cache full PR (748-second gate, 2,269 validation runner-seconds,
+about 9.3 minutes per browser suite); do not treat cold OCaml setup or runner
+queue time as a browser-sharding result.

--- a/website/scripts/browser-ci.mjs
+++ b/website/scripts/browser-ci.mjs
@@ -1,0 +1,171 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import assert from 'node:assert/strict';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+import { inventory, verifyArtifact } from './release-artifact.mjs';
+import {
+  browserShardCount,
+  qualifyBrowserShards,
+} from './browser-evidence.mjs';
+
+const site = fileURLToPath(new URL('../', import.meta.url));
+const read = async (file) => JSON.parse(await fs.readFile(file, 'utf8'));
+const [command, target, shardIndex] = process.argv.slice(2);
+assert.ok(
+  ['plan', 'run', 'merge'].includes(command) && target,
+  'Usage: browser-ci.mjs plan|run|merge ARTIFACT [SHARD]',
+);
+const directory = path.resolve(target);
+const artifact = await verifyArtifact(directory);
+const revision = execFileSync('git', ['rev-parse', 'HEAD'], {
+  cwd: site,
+  encoding: 'utf8',
+}).trim();
+assert.equal(
+  artifact.build.revision,
+  revision,
+  'Browser checkout differs from build',
+);
+assert.equal(
+  artifact.build.environment,
+  process.env.SITE_ENV,
+  'Browser environment differs from build',
+);
+assert.equal(
+  artifact.packageLockSha256,
+  createHash('sha256')
+    .update(await fs.readFile(path.join(site, 'package-lock.json')))
+    .digest('hex'),
+);
+const output = path.join(site, '.release/browser');
+await fs.mkdir(output, { recursive: true });
+const runId = process.env.GITHUB_RUN_ID || 'local';
+const env = {
+  ...process.env,
+  CI_BROWSER_ARTIFACT: path.join(directory, 'artifact.json'),
+  CI_BROWSER_REPORT: path.join(directory, 'browser-plan.json'),
+};
+const playwright = (args, extraEnv = {}) =>
+  spawnSync(
+    process.execPath,
+    [path.join(site, 'node_modules/@playwright/test/cli.js'), ...args],
+    {
+      cwd: site,
+      env: { ...env, ...extraEnv },
+      stdio: 'inherit',
+    },
+  );
+const succeeded = (result) =>
+  assert.equal(
+    result.status,
+    0,
+    `Playwright failed (${result.error || result.signal || result.status})`,
+  );
+if (command === 'plan') {
+  succeeded(
+    playwright(['test', '--list', '--reporter=./scripts/browser-reporter.mjs']),
+  );
+} else if (command === 'run') {
+  const index = Number(shardIndex);
+  assert.ok(
+    Number.isInteger(index) && index >= 1 && index <= browserShardCount,
+    'Invalid browser shard',
+  );
+  // Restore the built bytes and fixture reports, without invoking the generator
+  // or rebuilding on any shard. Verify the served copy before and after testing.
+  await fs.rm(path.join(site, 'dist'), { recursive: true, force: true });
+  await fs.rm(path.join(site, '.generated'), { recursive: true, force: true });
+  await fs.cp(path.join(directory, 'dist'), path.join(site, 'dist'), {
+    recursive: true,
+  });
+  await fs.cp(path.join(directory, 'evidence'), path.join(site, '.generated'), {
+    recursive: true,
+  });
+  const verifyServed = async () =>
+    assert.equal(
+      (await inventory(path.join(site, 'dist'))).sha256,
+      artifact.build.sha256,
+      'Served browser artifact changed',
+    );
+  await verifyServed();
+  const result = playwright(
+    [
+      'test',
+      `--shard=${index}/${browserShardCount}`,
+      '--workers=2',
+      '--reporter=list,blob,./scripts/browser-reporter.mjs',
+      `--output=${path.join(output, 'test-results')}`,
+    ],
+    {
+      CI_BROWSER_REPORT: path.join(output, 'shard.json'),
+      PLAYWRIGHT_BLOB_OUTPUT_DIR: path.join(output, 'blobs'),
+    },
+  );
+  await verifyServed();
+  succeeded(result);
+} else {
+  const input = path.join(site, '.release/shards');
+  assert.deepEqual(
+    (await fs.readdir(input)).sort(),
+    [1, 2].map(
+      (index) => `website-browser-${artifact.build.environment}-${index}`,
+    ),
+    'Missing or extra shard artifacts',
+  );
+  const plan = await read(path.join(directory, 'browser-plan.json'));
+  const blobs = path.join(output, 'blobs');
+  await fs.mkdir(blobs, { recursive: true });
+  const shards = [];
+  for (let index = 1; index <= browserShardCount; index++) {
+    const source = path.join(
+      input,
+      `website-browser-${artifact.build.environment}-${index}`,
+    );
+    shards.push(await read(path.join(source, 'shard.json')));
+    const files = (await fs.readdir(path.join(source, 'blobs'))).filter(
+      (name) => name.endsWith('.zip'),
+    );
+    assert.equal(files.length, 1, 'Expected one blob report per shard');
+    await fs.copyFile(
+      path.join(source, 'blobs', files[0]),
+      path.join(blobs, `shard-${index}.zip`),
+    );
+  }
+  // Retain a human-readable merged report even when execution evidence fails.
+  succeeded(
+    playwright(['merge-reports', '--reporter=html,json', blobs], {
+      PLAYWRIGHT_HTML_OUTPUT_DIR: path.join(output, 'html'),
+      PLAYWRIGHT_HTML_OPEN: 'never',
+      PLAYWRIGHT_JSON_OUTPUT_NAME: path.join(output, 'merged.json'),
+    }),
+  );
+  const counts = qualifyBrowserShards(plan, shards, artifact.build, runId);
+  const merged = await read(path.join(output, 'merged.json'));
+  assert.deepEqual(merged.errors, []);
+  assert.equal(merged.stats.unexpected, 0);
+  assert.equal(merged.stats.flaky, 0);
+  assert.equal(merged.stats.expected, counts.passed);
+  assert.equal(merged.stats.skipped, counts.skipped);
+  const result = {
+    version: 2,
+    status: 'passed',
+    failedTests: [],
+    runId,
+    plan,
+    shards,
+    counts,
+  };
+  await fs.writeFile(
+    path.join(directory, 'browser-result.json'),
+    JSON.stringify(result, null, 2) + '\n',
+  );
+  console.log(
+    JSON.stringify({
+      environment: artifact.build.environment,
+      ...counts,
+      result: 'pass',
+    }),
+  );
+}

--- a/website/scripts/browser-evidence.mjs
+++ b/website/scripts/browser-evidence.mjs
@@ -1,0 +1,117 @@
+import assert from 'node:assert/strict';
+
+export const browserShardCount = 2;
+const projects = ['chromium', 'firefox', 'webkit'];
+
+function checkIdentity(report, build, runId) {
+  assert.equal(report.version, 1, 'Unsupported browser evidence');
+  assert.equal(
+    report.environment,
+    build.environment,
+    'Browser environment mismatch',
+  );
+  assert.equal(report.revision, build.revision, 'Browser revision mismatch');
+  assert.equal(
+    report.artifactSha256,
+    build.sha256,
+    'Browser artifact mismatch',
+  );
+  assert.equal(report.runId, runId, 'Browser workflow run mismatch');
+  assert.equal(report.status, 'passed', 'Browser execution did not pass');
+  assert.deepEqual(report.errors, [], 'Browser runner reported errors');
+  assert.ok(report.tests.length > 0, 'Empty browser test evidence');
+}
+
+export function qualifyBrowserShards(plan, shards, build, runId) {
+  checkIdentity(plan, build, runId);
+  assert.equal(plan.shard, null, 'Expected an unsharded discovery plan');
+  assert.deepEqual(
+    [...new Set(plan.tests.map((t) => t.project))].sort(),
+    projects,
+  );
+  const expected = new Map(plan.tests.map((t) => [t.id, t.project]));
+  assert.equal(expected.size, plan.tests.length, 'Duplicate planned test');
+  assert.equal(
+    shards.length,
+    browserShardCount,
+    'Missing or extra browser shard',
+  );
+  const seenShards = new Set();
+  const seenTests = new Set();
+  let passed = 0,
+    skipped = 0;
+  for (const shard of shards) {
+    checkIdentity(shard, build, runId);
+    assert.equal(shard.shard?.total, browserShardCount, 'Wrong shard total');
+    const index = shard.shard.current;
+    assert.ok(
+      Number.isInteger(index) && index >= 1 && index <= browserShardCount,
+      'Invalid shard index',
+    );
+    assert.ok(!seenShards.has(index), 'Duplicate browser shard');
+    seenShards.add(index);
+    for (const test of shard.tests) {
+      assert.ok(expected.has(test.id), 'Unexpected browser test');
+      assert.equal(
+        test.project,
+        expected.get(test.id),
+        'Browser project mismatch',
+      );
+      assert.ok(
+        !seenTests.has(test.id),
+        'Duplicate browser test across shards',
+      );
+      seenTests.add(test.id);
+      assert.equal(test.results.length, 1, 'Test missing execution or retried');
+      assert.equal(
+        test.results[0].retry,
+        0,
+        'Browser retries must stay disabled',
+      );
+      if (test.expectedStatus === 'skipped') {
+        assert.equal(test.results[0].status, 'skipped');
+        assert.equal(test.outcome, 'skipped');
+        skipped++;
+      } else {
+        assert.equal(test.expectedStatus, 'passed');
+        assert.equal(
+          test.results[0].status,
+          'passed',
+          'Browser test did not pass',
+        );
+        assert.equal(test.outcome, 'expected');
+        passed++;
+      }
+    }
+  }
+  assert.equal(seenTests.size, expected.size, 'Missing browser tests');
+  assert.ok(passed > 0, 'No browser tests passed');
+  return { total: expected.size, passed, skipped };
+}
+
+export function checkBrowserQualification(
+  browser,
+  build,
+  runId = browser.runId,
+) {
+  assert.equal(
+    browser.version,
+    2,
+    'Complete sharded browser qualification required',
+  );
+  assert.equal(browser.status, 'passed');
+  assert.deepEqual(browser.failedTests, []);
+  assert.equal(browser.runId, runId);
+  const counts = qualifyBrowserShards(
+    browser.plan,
+    browser.shards,
+    build,
+    runId,
+  );
+  assert.deepEqual(
+    browser.counts,
+    counts,
+    'Browser summary disagrees with shard evidence',
+  );
+  return counts;
+}

--- a/website/scripts/browser-reporter.mjs
+++ b/website/scripts/browser-reporter.mjs
@@ -1,0 +1,49 @@
+import fs from 'node:fs';
+
+// Used for both discovery (--list) and execution. IDs come from Playwright,
+// so qualification can detect omitted or duplicated tests across machines.
+export default class BrowserReporter {
+  errors = [];
+  onBegin(config, suite) {
+    this.config = config;
+    this.suite = suite;
+  }
+  onError(error) {
+    this.errors.push(error.message || String(error));
+  }
+  onEnd(result) {
+    const artifact = JSON.parse(
+      fs.readFileSync(process.env.CI_BROWSER_ARTIFACT, 'utf8'),
+    );
+    fs.writeFileSync(
+      process.env.CI_BROWSER_REPORT,
+      JSON.stringify(
+        {
+          version: 1,
+          environment: artifact.build.environment,
+          revision: artifact.build.revision,
+          artifactSha256: artifact.build.sha256,
+          runId: process.env.GITHUB_RUN_ID || 'local',
+          runAttempt: process.env.GITHUB_RUN_ATTEMPT || 'local',
+          shard: this.config.shard,
+          status: result.status,
+          errors: this.errors,
+          durationMs: result.duration,
+          tests: this.suite.allTests().map((test) => ({
+            id: test.id,
+            project: test.parent.project().name,
+            title: test.titlePath().join(' > '),
+            expectedStatus: test.expectedStatus,
+            outcome: test.outcome(),
+            results: test.results.map((result) => ({
+              status: result.status,
+              retry: result.retry,
+            })),
+          })),
+        },
+        null,
+        2,
+      ) + '\n',
+    );
+  }
+}

--- a/website/scripts/verify-production.mjs
+++ b/website/scripts/verify-production.mjs
@@ -6,6 +6,7 @@ import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { verifyArtifact } from './release-artifact.mjs';
 import { checkApproval } from './release-approval.mjs';
+import { checkBrowserQualification } from './browser-evidence.mjs';
 import { productionOrigin } from '../config/production.mjs';
 
 const site = fileURLToPath(new URL('../', import.meta.url));
@@ -34,8 +35,7 @@ export function checkQualification(
   }
   assert.equal(search.environment, 'production');
   assert.equal(capacity.result, 'pass');
-  assert.equal(browser.status, 'passed');
-  assert.deepEqual(browser.failedTests, []);
+  checkBrowserQualification(browser, artifact.build, process.env.GITHUB_RUN_ID || browser.runId);
 }
 
 export async function verifyProduction(directory, semanticFile) {

--- a/website/tests/browser-evidence.test.mjs
+++ b/website/tests/browser-evidence.test.mjs
@@ -1,0 +1,153 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+import { browserFixture } from './fixtures/browser-evidence.mjs';
+import {
+  checkBrowserQualification,
+  qualifyBrowserShards,
+} from '../scripts/browser-evidence.mjs';
+
+const build = {
+  environment: 'production',
+  revision: 'a'.repeat(40),
+  sha256: 'b'.repeat(64),
+};
+
+test('browser qualification rejects missing, duplicate, stale, failed, cancelled, empty and partially executed shards', () => {
+  const good = browserFixture(build, '123');
+  assert.deepEqual(checkBrowserQualification(good, build, '123'), {
+    total: 6,
+    passed: 6,
+    skipped: 0,
+  });
+  for (const mutate of [
+    (b) => b.shards.pop(),
+    (b) => b.shards.push(b.shards[0]),
+    (b) => (b.shards[1].shard.current = 1),
+    (b) => (b.shards[1].shard.current = 3),
+    (b) => (b.shards[1].shard.total = 3),
+    (b) => (b.shards[1].environment = 'preview'),
+    (b) => (b.shards[1].revision = 'c'.repeat(40)),
+    (b) => (b.shards[1].artifactSha256 = 'c'.repeat(64)),
+    (b) => (b.shards[1].runId = '122'),
+    (b) => (b.shards[1].status = 'failed'),
+    (b) => (b.shards[1].status = 'interrupted'),
+    (b) => b.shards[1].errors.push('runner error'),
+    (b) => (b.shards[1].tests = []),
+    (b) => b.shards[1].tests.pop(),
+    (b) => b.shards[1].tests.push(b.shards[0].tests[0]),
+    (b) => (b.shards[1].tests[0].id = 'unknown'),
+    (b) => (b.shards[1].tests[0].project = 'unknown'),
+    (b) => (b.shards[1].tests[0].results = []),
+    (b) => (b.shards[1].tests[0].results[0].retry = 1),
+    (b) => (b.shards[1].tests[0].results[0].status = 'timedOut'),
+    (b) => b.plan.tests.push(b.plan.tests[0]),
+    (b) => b.plan.tests.forEach((t) => (t.project = 'chromium')),
+    (b) => (b.plan.shard = { current: 1, total: 2 }),
+    (b) => (b.plan.status = 'failed'),
+    (b) => (b.counts.total = 5),
+  ]) {
+    const changed = structuredClone(good);
+    mutate(changed);
+    assert.throws(() => checkBrowserQualification(changed, build, '123'));
+  }
+  assert.throws(() => checkBrowserQualification(good, build, 'other-run'));
+});
+
+test('real Playwright discovery, two shard reporters and blob merging preserve complete test identities and explicit skips', async () => {
+  const directory = await fs.mkdtemp(
+    path.join(os.tmpdir(), 'ochat-browser-shards-'),
+  );
+  const reporter = fileURLToPath(
+    new URL('../scripts/browser-reporter.mjs', import.meta.url),
+  );
+  const cli = fileURLToPath(
+    new URL('../node_modules/@playwright/test/cli.js', import.meta.url),
+  );
+  const playwrightImport = new URL(
+    '../node_modules/@playwright/test/index.mjs',
+    import.meta.url,
+  ).href;
+  const read = async (file) =>
+    JSON.parse(await fs.readFile(path.join(directory, file), 'utf8'));
+  try {
+    await fs.writeFile(
+      path.join(directory, 'artifact.json'),
+      JSON.stringify({ build }),
+    );
+    await fs.writeFile(
+      path.join(directory, 'fixture.spec.mjs'),
+      `import { test } from ${JSON.stringify(playwrightImport)};
+      test('first', () => {});
+      test('second', () => {});
+      test('explicit skip', () => { test.skip(true, 'Existing platform exception'); });`,
+    );
+    await fs.writeFile(
+      path.join(directory, 'config.mjs'),
+      `export default {
+      testDir: ${JSON.stringify(directory)}, testMatch: 'fixture.spec.mjs', fullyParallel: true, retries: 0,
+      projects: [{name:'chromium'}, {name:'firefox'}, {name:'webkit'}]
+    };`,
+    );
+    const run = (args, extra = {}) => {
+      const result = spawnSync(process.execPath, [cli, ...args], {
+        cwd: directory,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          GITHUB_RUN_ID: '123',
+          CI_BROWSER_ARTIFACT: path.join(directory, 'artifact.json'),
+          ...extra,
+        },
+      });
+      assert.equal(result.status, 0, result.stdout + result.stderr);
+    };
+    run(['test', '-c', 'config.mjs', '--list', `--reporter=${reporter}`], {
+      CI_BROWSER_REPORT: path.join(directory, 'plan.json'),
+    });
+    const shards = [];
+    await fs.mkdir(path.join(directory, 'blobs'));
+    for (const index of [1, 2]) {
+      run(
+        [
+          'test',
+          '-c',
+          'config.mjs',
+          `--shard=${index}/2`,
+          '--workers=2',
+          `--reporter=blob,${reporter}`,
+        ],
+        {
+          CI_BROWSER_REPORT: path.join(directory, `shard-${index}.json`),
+          PLAYWRIGHT_BLOB_OUTPUT_DIR: path.join(directory, `blob-${index}`),
+        },
+      );
+      shards.push(await read(`shard-${index}.json`));
+      for (const file of await fs.readdir(
+        path.join(directory, `blob-${index}`),
+      ))
+        await fs.copyFile(
+          path.join(directory, `blob-${index}`, file),
+          path.join(directory, 'blobs', file),
+        );
+    }
+    assert.deepEqual(
+      qualifyBrowserShards(await read('plan.json'), shards, build, '123'),
+      { total: 9, passed: 6, skipped: 3 },
+    );
+    run(['merge-reports', '--reporter=json', 'blobs'], {
+      PLAYWRIGHT_JSON_OUTPUT_NAME: path.join(directory, 'merged.json'),
+    });
+    const merged = await read('merged.json');
+    assert.deepEqual(merged.errors, []);
+    assert.equal(merged.stats.expected, 6);
+    assert.equal(merged.stats.skipped, 3);
+    assert.equal(merged.stats.unexpected, 0);
+  } finally {
+    await fs.rm(directory, { recursive: true, force: true });
+  }
+});

--- a/website/tests/deployment.test.mjs
+++ b/website/tests/deployment.test.mjs
@@ -19,6 +19,7 @@ import {
 } from '../scripts/release-approval.mjs';
 import { checkQualification } from '../scripts/verify-production.mjs';
 import redirectWorker from '../redirect/worker.mjs';
+import { browserFixture } from './fixtures/browser-evidence.mjs';
 
 test('public promotion honors the manual-review deferral and rejects incomplete hosted checks or stale evidence', () => {
   const artifact = {
@@ -105,6 +106,8 @@ test('workflow always detects changes, runs selected checks concurrently, and re
     'semantics',
     'framework',
     'website',
+    'browser',
+    'website-qualification',
   ]);
   assert.equal(gate.if, 'always()');
   const run = gate.steps.find((step) => step.env?.NEEDS_JSON);
@@ -305,7 +308,7 @@ test('production qualification rejects stale, preview, failed, or mismatched evi
     { result: 'pass', environment: 'production', artifactSha256: build.sha256 },
     { result: 'pass', artifactSha256: build.sha256 },
     { result: 'pass' },
-    { status: 'passed', failedTests: [] },
+    browserFixture(build),
     revision,
   ];
   checkQualification(...good);
@@ -340,6 +343,12 @@ test('production qualification rejects stale, preview, failed, or mismatched evi
     (args) => {
       args[5].status = 'failed';
     },
+    (args) => {
+      args[5] = { status: 'passed', failedTests: [] };
+    },
+    (args) => {
+      args[5].shards.pop();
+    },
   ]) {
     const args = structuredClone(good);
     mutate(args);
@@ -366,5 +375,72 @@ test('www redirect preserves encoded paths and query strings and rejects unrelat
   assert.equal(
     redirectWorker.fetch(new Request('https://unrelated.example/')).status,
     404,
+  );
+});
+
+test('browser shards consume a single build per environment and gate requires qualification', async () => {
+  const workflow = parse(
+    await fs.readFile(
+      new URL('../../.github/workflows/website.yml', import.meta.url),
+      'utf8',
+    ),
+  );
+  const {
+    website,
+    browser,
+    'website-qualification': qualification,
+  } = workflow.jobs;
+  assert.deepEqual(browser.needs, ['changes', 'website']);
+  assert.deepEqual(browser.strategy.matrix, {
+    environment: ['preview', 'production'],
+    shard: [1, 2],
+  });
+  assert.equal(browser.strategy['fail-fast'], false);
+  assert.deepEqual(qualification.needs, ['changes', 'website', 'browser']);
+  assert.equal(
+    qualification.if,
+    "!cancelled() && needs.changes.outputs.website == 'true' && needs.website.result == 'success'",
+  );
+  for (const job of [browser, qualification]) {
+    assert.ok(
+      !job.steps.some((step) => /npm run (build|content)/.test(step.run || '')),
+    );
+    assert.ok(
+      job.steps.some(
+        (step) =>
+          step.uses === 'actions/download-artifact@v4' &&
+          step.with.name === 'website-build-${{ matrix.environment }}',
+      ),
+    );
+  }
+  assert.equal(
+    website.steps.filter((step) => step.run === 'npm run build').length,
+    1,
+  );
+  assert.ok(
+    !website.steps.some(
+      (step) => step.with?.name === 'website-production-release',
+    ),
+  );
+  assert.ok(
+    browser.steps.some(
+      (step) =>
+        step.run ===
+        'node scripts/browser-ci.mjs run .release/candidate ${{ matrix.shard }}',
+    ),
+  );
+  assert.ok(
+    qualification.steps.some(
+      (step) =>
+        step.run === 'node scripts/browser-ci.mjs merge .release/candidate',
+    ),
+  );
+  assert.ok(
+    qualification.steps.some(
+      (step) =>
+        step.with?.name === 'website-production-release' &&
+        step.if ===
+          "matrix.environment == 'production' && needs.browser.result == 'success'",
+    ),
   );
 });

--- a/website/tests/fixtures/browser-evidence.mjs
+++ b/website/tests/fixtures/browser-evidence.mjs
@@ -1,0 +1,42 @@
+import { qualifyBrowserShards } from '../../scripts/browser-evidence.mjs';
+
+export function browserFixture(
+  build,
+  runId = process.env.GITHUB_RUN_ID || 'local',
+) {
+  const identity = {
+    version: 1,
+    environment: build.environment,
+    revision: build.revision,
+    artifactSha256: build.sha256,
+    runId,
+    status: 'passed',
+    errors: [],
+  };
+  const tests = ['chromium', 'firefox', 'webkit'].flatMap((project) =>
+    [1, 2].map((index) => ({
+      id: `${project}-${index}`,
+      project,
+      expectedStatus: 'passed',
+      outcome: 'expected',
+      results: [{ status: 'passed', retry: 0 }],
+    })),
+  );
+  const plan = { ...identity, shard: null, tests: structuredClone(tests) };
+  const shards = [1, 2].map((current) => ({
+    ...identity,
+    shard: { current, total: 2 },
+    tests: structuredClone(
+      tests.filter((_, index) => index % 2 === current - 1),
+    ),
+  }));
+  return {
+    version: 2,
+    status: 'passed',
+    failedTests: [],
+    runId,
+    plan,
+    shards,
+    counts: qualifyBrowserShards(plan, shards, build, runId),
+  };
+}


### PR DESCRIPTION
Browser suites took about 9.3 minutes per environment and determined much of the warm release-gate duration. Split each environment's browser suite across two runners while retaining Chromium, Firefox, WebKit, two workers per runner and zero retries.

Each environment builds once. Shards download and verify the exact prepared artifact, restore its fixture reports without rebuilding, and record individual test identities plus revision, artifact hash and workflow run. Qualification merges Playwright blob reports and requires both shard indices and every discovered test exactly once before retaining the production release. The required gate also explicitly requires browser and qualification job success. Production verification rechecks the complete shard evidence. Failure traces and merged HTML/JSON reports remain available; same-run failed-job reruns can reuse matching successful shards.

Validation: 87 local CI policy and website tests passed, including negative shard/coverage/identity cases and actual Playwright discovery, two-shard execution and blob merging. Actionlint and git diff checks passed. Full PR run34194852377 passed all checks:259passed+2existing skips per environment across261 unique test IDs; exact artifact and complete shard evidence independently verified. Gate9m56s versus previous12m28s (20% shorter); slowest browser shard5m20s versus previous~9m20s. Summed validation runner time2237s versus2269s. All3dependencycaches hit in this run, while the baseline had mixed caches; these are observed results, not a guarantee of identical savings. Actual main deployment is verified after the protected merge.
