### PR TITLE
Handle existing evidence artifacts consistently on CI job reruns

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -52,6 +52,7 @@ jobs:
         if: always()
         with:
           name: ci-selection
+          overwrite: true
           path: .ci-evidence/selection.json
           include-hidden-files: true
           retention-days: 90
@@ -84,6 +85,7 @@ jobs:
         with:
           include-hidden-files: true
           name: website-semantic-evidence
+          overwrite: true
           path: |
             website/.release/semantic-report.json
             website/.release/opam-packages.txt
@@ -119,6 +121,7 @@ jobs:
         if: always()
         with:
           name: framework-evidence-${{ matrix.tier }}
+          overwrite: true
           include-hidden-files: true
           retention-days: 90
           path: |
@@ -365,6 +368,7 @@ jobs:
         if: always()
         with:
           name: production-deployment-evidence
+          overwrite: true
           path: |
             website/.release/deployment.json
             website/.release/hosted-production.json

--- a/website/planning/ci-enforcement.md
+++ b/website/planning/ci-enforcement.md
@@ -55,6 +55,20 @@ successful shards from an earlier attempt of that same run when the artifact
 hash and revision match; rerun uploads replace their own named evidence.
 A previous run's browser summary cannot qualify a new release.
 
+All named evidence uploads use `overwrite: true`, including change selection,
+semantic reports, framework tiers and production-deployment evidence. A job rerun
+replaces its own artifact under the existing name, so a successful retry does
+not fail solely because that name was uploaded by the earlier attempt. Upload
+errors still fail jobs; replacement does not waive any test or release check.
+
+Replacement deletes the previous artifact and creates a new artifact ID. Download
+an earlier attempt's evidence before rerunning if you need to preserve it; the
+named artifact represents the latest upload, not a history of every attempt.
+Other jobs' artifacts are not replaced by that job. Consumers continue to use
+same-run names and verify the required revision and content hashes. A retried
+publisher must still target current main and pass exact-release verification.
+See the [artifact upload contract](https://github.com/actions/upload-artifact/blob/v4/README.md#inputs).
+
 The additional runners and artifact transfer have overhead. Compare time to the
 required gate, individual browser durations, total validation runner time and
 failures in the [qualification record](ci-qualification.md) before expanding

--- a/website/tests/deployment.test.mjs
+++ b/website/tests/deployment.test.mjs
@@ -21,6 +21,53 @@ import { checkQualification } from '../scripts/verify-production.mjs';
 import redirectWorker from '../redirect/worker.mjs';
 import { browserFixture } from './fixtures/browser-evidence.mjs';
 
+test('every named evidence upload replaces its previous attempt without masking upload failures', async () => {
+  const workflow = parse(
+    await fs.readFile(
+      new URL('../../.github/workflows/website.yml', import.meta.url),
+      'utf8',
+    ),
+  );
+  const uploads = Object.entries(workflow.jobs).flatMap(([job, config]) =>
+    config.steps
+      .filter((step) => step.uses?.startsWith('actions/upload-artifact@'))
+      .map((step) => ({ job, step })),
+  );
+  assert.ok(uploads.length > 0);
+  for (const { job, step } of uploads) {
+    assert.ok(step.with.name, `${job}: evidence must have an explicit name`);
+    assert.equal(
+      step.with.overwrite,
+      true,
+      `${job}/${step.with.name}: reruns must replace evidence`,
+    );
+    assert.ok(
+      !step['continue-on-error'],
+      `${job}: upload failures must remain failures`,
+    );
+  }
+  for (const [job, name] of Object.entries({
+    changes: 'ci-selection',
+    semantics: 'website-semantic-evidence',
+    framework: 'framework-evidence-${{ matrix.tier }}',
+    'deploy-production': 'production-deployment-evidence',
+  })) {
+    const found = uploads.filter(
+      (upload) => upload.job === job && upload.step.with.name === name,
+    );
+    assert.equal(
+      found.length,
+      1,
+      `${job}: preserve the existing evidence name`,
+    );
+    assert.equal(
+      found[0].step.if,
+      'always()',
+      `${job}: retain failed-attempt diagnostics`,
+    );
+  }
+});
+
 test('public promotion honors the manual-review deferral and rejects incomplete hosted checks or stale evidence', () => {
   const artifact = {
     build: {


### PR DESCRIPTION
A rerun can pass its tests but fail to upload evidence when the previous attempt already created the same artifact name. Enable the existing overwrite behavior for change-selection, semantic, framework-tier, and production-deployment evidence, completing the policy already used by website/browser artifacts.

Add a workflow regression check requiring explicit names, replacement on reruns, and unmasked upload failures while preserving existing evidence names and always-upload diagnostics. Document that replacement creates a new artifact ID and that earlier evidence should be downloaded before rerunning when its history is needed.

Validation:

- All 19 targeted CI policy/deployment tests, Actionlint, and diff checks passed locally.
- Full PR run [34199911077](https://github.com/dakotamurphyucf/ochat/actions/runs/34199911077) passed all selected validation. An actual framework E2E job rerun on the same commit/run then passed, including the release gate: artifact ID 10045743486 was replaced by 10045981045 under the same name, and all 14 other artifact IDs remained unchanged. Both E2E reports passed with the same revision and command and a fresh execution timestamp. Original evidence and before/after metadata were retained locally. This exercised a completed passing job with an existing artifact; no test failure was injected.
- After normal protected merge, main run [34201656595](https://github.com/dakotamurphyucf/ochat/actions/runs/34201656595) passed normal Dune tests, E2E, semantics, both website builds, all four browser shards, both qualifiers, release-gate and production deployment. Independent artifact reconciliation, exact production verification, 27 GitHub policy checks and all 3,594 hosted checks passed against merge commit 8405d2d0d589f5e133f1d5c55ef49b17787fdd0d.

Live Dune log streaming remains deferred.
